### PR TITLE
add schemaOrderedComparison for SchemaComparer

### DIFF
--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
@@ -12,6 +12,7 @@ trait DataFrameComparer extends DatasetComparer {
                                    ignoreNullable: Boolean = false,
                                    ignoreColumnNames: Boolean = false,
                                    orderedComparison: Boolean = true,
+                                   schemaOrderedComparison: Boolean = true,
                                    truncate: Int = 500): Unit = {
     assertSmallDatasetEquality(
       actualDF,
@@ -19,6 +20,7 @@ trait DataFrameComparer extends DatasetComparer {
       ignoreNullable,
       ignoreColumnNames,
       orderedComparison,
+      schemaOrderedComparison,
       truncate
     )
   }
@@ -30,13 +32,15 @@ trait DataFrameComparer extends DatasetComparer {
                                    expectedDF: DataFrame,
                                    ignoreNullable: Boolean = false,
                                    ignoreColumnNames: Boolean = false,
-                                   orderedComparison: Boolean = true): Unit = {
+                                   orderedComparison: Boolean = true,
+                                   schemaOrderedComparison: Boolean = true): Unit = {
     assertLargeDatasetEquality(
       actualDF,
       expectedDF,
       ignoreNullable = ignoreNullable,
       ignoreColumnNames = ignoreColumnNames,
-      orderedComparison = orderedComparison
+      orderedComparison = orderedComparison,
+      schemaOrderedComparison = schemaOrderedComparison
     )
   }
 

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -81,8 +81,9 @@ Expected DataFrame Row Count: '${expectedCount}'
                                     ignoreNullable: Boolean = false,
                                     ignoreColumnNames: Boolean = false,
                                     orderedComparison: Boolean = true,
+                                    schemaOrderedComparison: Boolean = true,
                                     truncate: Int = 500): Unit = {
-    if (!SchemaComparer.equals(actualDS.schema, expectedDS.schema, ignoreNullable, ignoreColumnNames)) {
+    if (!SchemaComparer.equals(actualDS.schema, expectedDS.schema, ignoreNullable, ignoreColumnNames, schemaOrderedComparison)) {
       throw DatasetSchemaMismatch(
         betterSchemaMismatchMessage(actualDS, expectedDS)
       )
@@ -126,9 +127,10 @@ Expected DataFrame Row Count: '${expectedCount}'
                                               equals: (T, T) => Boolean = naiveEquality _,
                                               ignoreNullable: Boolean = false,
                                               ignoreColumnNames: Boolean = false,
-                                              orderedComparison: Boolean = true): Unit = {
+                                              orderedComparison: Boolean = true,
+                                              schemaOrderedComparison: Boolean = true): Unit = {
     // first check if the schemas are equal
-    if (!SchemaComparer.equals(actualDS.schema, expectedDS.schema, ignoreNullable, ignoreColumnNames)) {
+    if (!SchemaComparer.equals(actualDS.schema, expectedDS.schema, ignoreNullable, ignoreColumnNames, schemaOrderedComparison)) {
       throw DatasetSchemaMismatch(betterSchemaMismatchMessage(actualDS, expectedDS))
     }
     // then check if the DataFrames have the same content
@@ -177,7 +179,8 @@ Expected DataFrame Row Count: '${expectedCount}'
                                          precision: Double,
                                          ignoreNullable: Boolean = false,
                                          ignoreColumnNames: Boolean = false,
-                                         orderedComparison: Boolean = true): Unit = {
+                                         orderedComparison: Boolean = true,
+                                         schemaOrderedComparison: Boolean = true): Unit = {
     val e = (r1: Row, r2: Row) => {
       r1.equals(r2) || RowComparer.areRowsEqual(r1, r2, precision)
     }
@@ -187,7 +190,8 @@ Expected DataFrame Row Count: '${expectedCount}'
       equals = e,
       ignoreNullable,
       ignoreColumnNames,
-      orderedComparison
+      orderedComparison,
+      schemaOrderedComparison
     )
   }
 

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
@@ -4,11 +4,20 @@ import org.apache.spark.sql.types.{StructField, StructType}
 
 object SchemaComparer {
 
-  def equals(s1: StructType, s2: StructType, ignoreNullable: Boolean = false, ignoreColumnNames: Boolean = false): Boolean = {
+  def equals(s1: StructType,
+             s2: StructType,
+             ignoreNullable: Boolean = false,
+             ignoreColumnNames: Boolean = false,
+             schemaOrderedComparison: Boolean = true): Boolean = {
     if (s1.length != s2.length) {
       false
     } else {
-      val structFields: Seq[(StructField, StructField)] = s1.zip(s2)
+      val structFields: Seq[(StructField, StructField)] =
+        if (schemaOrderedComparison)
+          s1.zip(s2)
+        else {
+          s1.sortBy(_.name).zip(s2.sortBy(_.name))
+        }
       structFields.forall { t =>
         ((t._1.nullable == t._2.nullable) || ignoreNullable) &&
         ((t._1.name == t._2.name) || ignoreColumnNames) &&

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
@@ -84,6 +84,38 @@ class SchemaComparerTest extends FreeSpec {
       assert(SchemaComparer.equals(s1, s2, ignoreColumnNames = true))
     }
 
+    "returns true if the schemas not in the same order and schemaOrderedComparison is set to false" in {
+      val s1 = StructType(
+        Seq(
+          StructField("mood", StringType, true),
+          StructField("something", StringType, true)
+        )
+      )
+      val s2 = StructType(
+        Seq(
+          StructField("something", StringType, true),
+          StructField("mood", StringType, true)
+        )
+      )
+      assert(SchemaComparer.equals(s1, s2, schemaOrderedComparison = false))
+    }
+
+    "returns false if the schemas not in the same order and schemaOrderedComparison is set to true" in {
+      val s1 = StructType(
+        Seq(
+          StructField("mood", StringType, true),
+          StructField("something", StringType, true)
+        )
+      )
+      val s2 = StructType(
+        Seq(
+          StructField("something", StringType, true),
+          StructField("mood", StringType, true)
+        )
+      )
+      assert(!SchemaComparer.equals(s1, s2, schemaOrderedComparison = true))
+    }
+
   }
 
 }


### PR DESCRIPTION
It can be useful to test if schemas are equals even if the ordering is different.
By default, the behavior is the same as previous.