### PR TITLE
Updates spark in the CI and more dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spark: ["2.4.8","3.0.3","3.1.3","3.2.1"]
+        spark: ["2.4.8","3.0.3","3.1.3","3.2.4", "3.3.2", "3.4.0"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-scalafmtOnCompile in Compile := true
+Compile / scalafmtOnCompile := true
 
 organization := "com.github.mrpowers"
 name := "spark-fast-tests"
@@ -11,11 +11,11 @@ val versionRegex      = """^(.*)\.(.*)\.(.*)$""".r
 
 val sparkVersion = settingKey[String]("Spark version")
 
-val scala2_13= "2.13.8"
-val scala2_12= "2.12.15"
+val scala2_13= "2.13.10"
+val scala2_12= "2.12.17"
 val scala2_11= "2.11.12"
 
-sparkVersion := System.getProperty("spark.testVersion", "3.2.1")
+sparkVersion := System.getProperty("spark.testVersion", "3.4.0")
 crossScalaVersions := {sparkVersion.value match {
   case versionRegex("3", m, _) if m.toInt >= 2 => Seq(scala2_12, scala2_13)
   case versionRegex("3", _ , _) => Seq(scala2_12)
@@ -26,11 +26,11 @@ crossScalaVersions := {sparkVersion.value match {
 scalaVersion := crossScalaVersions.value.head
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15" % "test"
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
 
-fork in Test := true
+Test/ fork := true
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled", "-Duser.timezone=GMT")
 
 licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/ArrayUtilTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/ArrayUtilTest.scala
@@ -2,9 +2,9 @@ package com.github.mrpowers.spark.fast.tests
 
 import java.sql.Date
 import java.time.LocalDate
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class ArrayUtilTest extends FreeSpec {
+class ArrayUtilTest extends AnyFreeSpec {
 
   "blah" in {
     val arr: Array[(Any, Any)] = Array(("hi", "there"), ("fun", "train"))

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerTest.scala
@@ -1,14 +1,13 @@
 package com.github.mrpowers.spark.fast.tests
 
+import java.sql.{Date, Timestamp}
+import org.scalatest.freespec.AnyFreeSpec
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
-import java.sql.Date
-import java.sql.Timestamp
 
-import org.scalatest.FreeSpec
-
-class ColumnComparerTest extends FreeSpec with ColumnComparer with SparkSessionTestWrapper {
+class ColumnComparerTest extends AnyFreeSpec with ColumnComparer with SparkSessionTestWrapper {
 
   "assertColumnEquality" - {
 
@@ -176,15 +175,18 @@ class ColumnComparerTest extends FreeSpec with ColumnComparer with SparkSessionT
       )
       val actualDF = sourceDF.withColumn(
         "colors",
-        split(
-          concat_ws(
-            ",",
-            when(col("words").contains("blue"), "blue"),
-            when(col("words").contains("red"), "red"),
-            when(col("words").contains("pink"), "pink"),
-            when(col("words").contains("cyan"), "cyan")
+        coalesce(
+          split(
+            concat_ws(
+              ",",
+              when(col("words").contains("blue"), "blue"),
+              when(col("words").contains("red"), "red"),
+              when(col("words").contains("pink"), "pink"),
+              when(col("words").contains("cyan"), "cyan")
+            ),
+            ","
           ),
-          ","
+          typedLit(Array())
         )
       )
       assertColumnEquality(actualDF, "colors", "expected_colors")

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -1,11 +1,11 @@
 package com.github.mrpowers.spark.fast.tests
 
+import com.github.mrpowers.spark.fast.tests.SparkSessionExt._
+import org.scalatest.freespec.AnyFreeSpec
+
 import org.apache.spark.sql.types.{IntegerType, StringType}
-import SparkSessionExt._
 
-import org.scalatest.FreeSpec
-
-class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSessionTestWrapper {
+class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with SparkSessionTestWrapper {
 
   "prints a descriptive error message if it bugs out" in {
     val sourceDF = spark.createDF(

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -1,9 +1,9 @@
 package com.github.mrpowers.spark.fast.tests
 
-import org.apache.spark.sql.types._
-import SparkSessionExt._
+import com.github.mrpowers.spark.fast.tests.SparkSessionExt._
+import org.scalatest.freespec.AnyFreeSpec
 
-import org.scalatest.FreeSpec
+import org.apache.spark.sql.types._
 
 object Person {
 
@@ -14,7 +14,7 @@ object Person {
 case class Person(name: String, age: Int)
 case class PrecisePerson(name: String, age: Double)
 
-class DatasetComparerTest extends FreeSpec with DatasetComparer with SparkSessionTestWrapper {
+class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSessionTestWrapper {
 
   "checkDatasetEquality" - {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/RDDComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/RDDComparerTest.scala
@@ -1,8 +1,8 @@
 package com.github.mrpowers.spark.fast.tests
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class RDDComparerTest extends FreeSpec with RDDComparer with SparkSessionTestWrapper {
+class RDDComparerTest extends AnyFreeSpec with RDDComparer with SparkSessionTestWrapper {
 
   "contentMismatchMessage" - {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/RowComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/RowComparerTest.scala
@@ -1,10 +1,10 @@
 package com.github.mrpowers.spark.fast.tests
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 import org.apache.spark.sql.Row
 
-class RowComparerTest extends FreeSpec {
+class RowComparerTest extends AnyFreeSpec {
 
   "areRowsEqual" - {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
@@ -1,9 +1,10 @@
 package com.github.mrpowers.spark.fast.tests
 
-import org.apache.spark.sql.types._
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class SchemaComparerTest extends FreeSpec {
+import org.apache.spark.sql.types._
+
+class SchemaComparerTest extends AnyFreeSpec {
 
   "equals" - {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/SparkSessionTestWrapper.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/SparkSessionTestWrapper.scala
@@ -5,12 +5,16 @@ import org.apache.spark.sql.SparkSession
 trait SparkSessionTestWrapper {
 
   lazy val spark: SparkSession = {
-    SparkSession
+    val ss = SparkSession
       .builder()
       .master("local")
       .appName("spark session")
       .config("spark.sql.shuffle.partitions", "1")
       .getOrCreate()
+
+    ss.sparkContext.setLogLevel("ERROR")
+
+    ss
   }
 
 }


### PR DESCRIPTION
Updated CI to test against 3.3.x and 3.4.x spark versions. Updated also scala test dependencies and scala used versions.

For the update, I've changed the spec from "scala-test" from FreeSpec to AnyFreeSpec.
One test failed due to changes in the schema that the example produced, it's fixed by ensuring that the column is not nullable.