### PR TITLE
Feature: add ignore Column Ordering in Dataset and Dataframe comparison

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-scalafmtOnCompile in Compile := true
+Compile / scalafmtOnCompile := true
 
 organization := "com.github.mrpowers"
 name := "spark-fast-tests"
@@ -30,7 +30,7 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0" % "test"
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
 
-fork in Test := true
+Test / fork  := true
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled", "-Duser.timezone=GMT")
 
 licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
@@ -32,12 +32,14 @@ trait DataFrameComparer extends DatasetComparer {
                                    expectedDF: DataFrame,
                                    ignoreNullable: Boolean = false,
                                    ignoreColumnNames: Boolean = false,
+                                   ignoreColumnOrder: Boolean = false,
                                    orderedComparison: Boolean = true): Unit = {
     assertLargeDatasetEquality(
       actualDF,
       expectedDF,
       ignoreNullable = ignoreNullable,
       ignoreColumnNames = ignoreColumnNames,
+      ignoreColumnOrder = ignoreColumnOrder,
       orderedComparison = orderedComparison
     )
   }

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
@@ -12,7 +12,7 @@ trait DataFrameComparer extends DatasetComparer {
                                    ignoreNullable: Boolean = false,
                                    ignoreColumnNames: Boolean = false,
                                    orderedComparison: Boolean = true,
-                                   orderedColumnComparison: Boolean = true,
+                                   ignoreColumnOrder: Boolean = false,
                                    truncate: Int = 500): Unit = {
     assertSmallDatasetEquality(
       actualDF,
@@ -20,7 +20,7 @@ trait DataFrameComparer extends DatasetComparer {
       ignoreNullable,
       ignoreColumnNames,
       orderedComparison,
-      orderedColumnComparison,
+      ignoreColumnOrder,
       truncate
     )
   }

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparer.scala
@@ -12,6 +12,7 @@ trait DataFrameComparer extends DatasetComparer {
                                    ignoreNullable: Boolean = false,
                                    ignoreColumnNames: Boolean = false,
                                    orderedComparison: Boolean = true,
+                                   orderedColumnComparison: Boolean = true,
                                    truncate: Int = 500): Unit = {
     assertSmallDatasetEquality(
       actualDF,
@@ -19,6 +20,7 @@ trait DataFrameComparer extends DatasetComparer {
       ignoreNullable,
       ignoreColumnNames,
       orderedComparison,
+      orderedColumnComparison,
       truncate
     )
   }

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -119,7 +119,6 @@ Expected DataFrame Row Count: '${expectedCount}'
         throw DatasetContentMismatch(betterContentMismatchMessage(a, e, truncate))
       }
     }
-    //}
   }
 
   def defaultSortDataset[T](ds: Dataset[T]): Dataset[T] = {

--- a/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
+++ b/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
@@ -4,25 +4,38 @@ import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, St
 
 object SchemaComparer {
 
-  def equals(s1: StructType, s2: StructType, ignoreNullable: Boolean = false, ignoreColumnNames: Boolean = false): Boolean = {
+  def equals(s1: StructType,
+             s2: StructType,
+             ignoreNullable: Boolean = false,
+             ignoreColumnNames: Boolean = false,
+             ignoreColumnOrder: Boolean = false): Boolean = {
     if (s1.length != s2.length) {
       false
     } else {
-      val structFields: Seq[(StructField, StructField)] = s1.zip(s2)
+      val structFields: Seq[(StructField, StructField)] = if (ignoreColumnOrder) {
+        s1.sortBy(_.name) zip s2.sortBy(_.name)
+      } else {
+        s1 zip s2
+      }
+
       structFields.forall { t =>
         ((t._1.nullable == t._2.nullable) || ignoreNullable) &&
         ((t._1.name == t._2.name) || ignoreColumnNames) &&
-        equals(t._1.dataType, t._2.dataType, ignoreNullable, ignoreColumnNames)
+        equals(t._1.dataType, t._2.dataType, ignoreNullable, ignoreColumnNames, ignoreColumnOrder)
       }
     }
   }
 
-  def equals(dt1: DataType, dt2: DataType, ignoreNullable: Boolean, ignoreColumnNames: Boolean): Boolean = {
-    (ignoreNullable, dt1, dt2) match {
-      case (true, st1: StructType, st2: StructType)       => equals(st1, st2, ignoreNullable, ignoreColumnNames)
-      case (true, ArrayType(vdt1, _), ArrayType(vdt2, _)) => equals(vdt1, vdt2, ignoreNullable, ignoreColumnNames)
-      case (true, MapType(kdt1, vdt1, _), MapType(kdt2, vdt2, _)) =>
-        equals(kdt1, kdt2, ignoreNullable, ignoreColumnNames) && equals(vdt1, vdt2, ignoreNullable, ignoreColumnNames)
+  def equals(dt1: DataType, dt2: DataType, ignoreNullable: Boolean, ignoreColumnNames: Boolean, ignoreColumnOrder: Boolean): Boolean = {
+    (dt1, dt2) match {
+      case (st1: StructType, st2: StructType)       => equals(st1, st2, ignoreNullable, ignoreColumnNames, ignoreColumnOrder)
+      case (ArrayType(vdt1, _), ArrayType(vdt2, _)) => equals(vdt1, vdt2, ignoreNullable, ignoreColumnNames, ignoreColumnOrder)
+      case (MapType(kdt1, vdt1, _), MapType(kdt2, vdt2, _)) =>
+        equals(kdt1, kdt2, ignoreNullable, ignoreColumnNames, ignoreColumnOrder) && equals(vdt1,
+                                                                                           vdt2,
+                                                                                           ignoreNullable,
+                                                                                           ignoreColumnNames,
+                                                                                           ignoreColumnOrder)
       case _ => dt1 == dt2
     }
   }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -254,6 +254,105 @@ class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSe
       }
     }
 
-  }
+    "can performed unordered schema DataFrame comparisons" in {
+      val sourceDF = spark.createDF(
+        List(
+          (1, "word"),
+          (5, "word")
+        ),
+        List(
+          ("number", IntegerType, true),
+          ("word", StringType, true)
+        )
+      )
+      val expectedDF = spark.createDF(
+        List(
+          ("word", 1),
+          ("word", 5)
+        ),
+        List(
+          ("word", StringType, true),
+          ("number", IntegerType, true)
+        )
+      )
+      assertSmallDataFrameEquality(sourceDF, expectedDF, orderedColumnComparison = false)
+    }
 
+    "can performed unordered schema and unordered row DataFrame comparisons" in {
+      val sourceDF = spark.createDF(
+        List(
+          (5, "word"),
+          (1, "word")
+        ),
+        List(
+          ("number", IntegerType, true),
+          ("word", StringType, true)
+        )
+      )
+      val expectedDF = spark.createDF(
+        List(
+          ("word", 1),
+          ("word", 5)
+        ),
+        List(
+          ("word", StringType, true),
+          ("number", IntegerType, true)
+        )
+      )
+      assertSmallDataFrameEquality(sourceDF, expectedDF, orderedComparison = false, orderedColumnComparison = false)
+    }
+
+    "throws an error for unordered column DataFrame comparisons that don't match" in {
+      val sourceDF = spark.createDF(
+        List(
+          (5, "word"),
+          (5, "word")
+        ),
+        List(
+          ("number", IntegerType, true),
+          ("word", StringType, true)
+        )
+      )
+      val expectedDF = spark.createDF(
+        List(
+          ("word", 1),
+          ("word", 5)
+        ),
+        List(
+          ("word", StringType, true),
+          ("number", IntegerType, true)
+        )
+      )
+      val e = intercept[DatasetContentMismatch] {
+        assertSmallDataFrameEquality(sourceDF, expectedDF, orderedColumnComparison = false)
+      }
+
+    }
+
+    "throws an error if both ignore column names and ignore column ordering" in {
+      val sourceDF = spark.createDF(
+        List(
+          (1, "word"),
+          (5, "word")
+        ),
+        List(
+          ("number", IntegerType, true),
+          ("word", StringType, true)
+        )
+      )
+      val expectedDF = spark.createDF(
+        List(
+          ("word", 1),
+          ("word", 5)
+        ),
+        List(
+          ("word", StringType, true),
+          ("number", IntegerType, true)
+        )
+      )
+      val e = intercept[IllegalArgumentException] {
+        assertSmallDataFrameEquality(sourceDF, expectedDF, ignoreColumnNames = true, orderedColumnComparison = false)
+      }
+    }
+  }
 }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -354,7 +354,7 @@ class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSe
       }
     }
 
-    "does not throw an error if schemas, regardless of order, do not match" in {
+    "throw an error if schemas, regardless of order, do not match" in {
       val sourceDF = spark.createDF(
         List(
           ("word", 1, false),


### PR DESCRIPTION
Adding the option to ignore column ordering. This is done by sorting the the dataset by column names. Consequently, this option is incompatible with ignoreColumnNames. 
