### PR TITLE
Package version upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spark: ["2.4.8","3.0.3","3.1.3","3.2.1"]
+        spark: ["3.1.3","3.2.1", "3.3.2", "3.4.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spark: ["3.1.3","3.2.1", "3.3.2", "3.4.2"]
+        spark: ["3.1.3","3.2.1", "3.3.2", "3.4.3", "3.5.1"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,6 +3,7 @@ version = 3.8.2
 align.preset = more
 runner.dialect = scala212
 maxColumn = 150
+lineEndings=preserve
 docstrings.style = Asterisk
 
 //style = defaultWithAlign

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,7 +3,6 @@ version = 3.8.2
 align.preset = more
 runner.dialect = scala212
 maxColumn = 150
-lineEndings=preserve
 docstrings.style = Asterisk
 
 //style = defaultWithAlign

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ Fetch the JAR file from Maven.
 ```scala
 // for Spark 3
 libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "1.1.0" % "test"
-
-// for Spark 2
-libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "0.23.0" % "test"
 ```
 
 Here's a link to the releases for different Scala versions:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Fetch the JAR file from Maven.
 // for Spark 3
 libraryDependencies += "com.github.mrpowers" %% "spark-fast-tests" % "1.1.0" % "test"
 ```
+**Important: Future versions of spark-fast-test will no longer support Spark 2.x. We recommend upgrading to Spark 3.x to ensure compatibility with upcoming releases.**
 
 Here's a link to the releases for different Scala versions:
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,4 @@
-enablePlugins(GitVersioning)
-
-scalafmtOnCompile in Compile := true
+Compile / scalafmtOnCompile:= true
 
 organization := "com.github.mrpowers"
 name := "spark-fast-tests"
@@ -11,11 +9,11 @@ val versionRegex      = """^(.*)\.(.*)\.(.*)$""".r
 
 val sparkVersion = settingKey[String]("Spark version")
 
-val scala2_13= "2.13.8"
+val scala2_13= "2.13.13"
 val scala2_12= "2.12.15"
-val scala2_11= "2.11.12"
+val scala2_11= "2.11.17"
 
-sparkVersion := System.getProperty("spark.testVersion", "3.2.1")
+sparkVersion := System.getProperty("spark.testVersion", "3.4.2")
 crossScalaVersions := {sparkVersion.value match {
   case versionRegex("3", m, _) if m.toInt >= 2 => Seq(scala2_12, scala2_13)
   case versionRegex("3", _ , _) => Seq(scala2_12)
@@ -24,13 +22,14 @@ crossScalaVersions := {sparkVersion.value match {
 }
 
 scalaVersion := crossScalaVersions.value.head
+enablePlugins(JmhPlugin)
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0" % "test"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion.value % "compile"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
 
-fork in Test := true
+Test / fork := true
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled", "-Duser.timezone=GMT")
 
 licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
@@ -44,6 +43,6 @@ updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 publishMavenStyle := true
 
-publishTo := sonatypePublishToBundle.value
+// publishTo := sonatypePublishToBundle.value
 
-Global/useGpgPinentry := true
+// Global / useGpgPinentry := true

--- a/build.sbt
+++ b/build.sbt
@@ -14,18 +14,19 @@ val scala2_13= "2.13.13"
 val scala2_12= "2.12.15"
 val scala2_11= "2.11.17"
 
-sparkVersion := System.getProperty("spark.testVersion", "3.4.2")
-crossScalaVersions := {sparkVersion.value match {
-  case versionRegex("3", m, _) if m.toInt >= 2 => Seq(scala2_12, scala2_13)
-  case versionRegex("3", _ , _) => Seq(scala2_12)
-  case versionRegex("2", _ , _)  => Seq(scala2_11)
-}
+sparkVersion := System.getProperty("spark.testVersion", "3.5.1")
+crossScalaVersions := {
+  sparkVersion.value match {
+    case versionRegex("3", m, _) if m.toInt >= 2 => Seq(scala2_12, scala2_13)
+    case versionRegex("3", _ , _)                => Seq(scala2_12)
+    case versionRegex("2", _ , _)                => Seq(scala2_11)
+  }
 }
 
 scalaVersion := crossScalaVersions.value.head
 enablePlugins(JmhPlugin)
 
-libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion.value % "compile"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ crossScalaVersions := {
 }
 
 scalaVersion := crossScalaVersions.value.head
-enablePlugins(JmhPlugin)
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,6 @@ updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 publishMavenStyle := true
 
-// publishTo := sonatypePublishToBundle.value
+publishTo := sonatypePublishToBundle.value
 
-// Global / useGpgPinentry := true
+Global / useGpgPinentry := true

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ crossScalaVersions := {
   sparkVersion.value match {
     case versionRegex("3", m, _) if m.toInt >= 2 => Seq(scala2_12, scala2_13)
     case versionRegex("3", _ , _)                => Seq(scala2_12)
-    case versionRegex("2", _ , _)                => Seq(scala2_11)
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+enablePlugins(GitVersioning)
 Compile / scalafmtOnCompile:= true
 
 organization := "com.github.mrpowers"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,6 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
-
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,7 @@ resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
+
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,4 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/ArrayUtilTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/ArrayUtilTest.scala
@@ -2,9 +2,9 @@ package com.github.mrpowers.spark.fast.tests
 
 import java.sql.Date
 import java.time.LocalDate
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class ArrayUtilTest extends FreeSpec {
+class ArrayUtilTest extends AnyFreeSpec {
 
   "blah" in {
     val arr: Array[(Any, Any)] = Array(("hi", "there"), ("fun", "train"))

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/ColumnComparerTest.scala
@@ -6,9 +6,9 @@ import org.apache.spark.sql.types._
 import java.sql.Date
 import java.sql.Timestamp
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class ColumnComparerTest extends FreeSpec with ColumnComparer with SparkSessionTestWrapper {
+class ColumnComparerTest extends AnyFreeSpec with ColumnComparer with SparkSessionTestWrapper {
 
   "assertColumnEquality" - {
 
@@ -176,15 +176,18 @@ class ColumnComparerTest extends FreeSpec with ColumnComparer with SparkSessionT
       )
       val actualDF = sourceDF.withColumn(
         "colors",
-        split(
-          concat_ws(
-            ",",
-            when(col("words").contains("blue"), "blue"),
-            when(col("words").contains("red"), "red"),
-            when(col("words").contains("pink"), "pink"),
-            when(col("words").contains("cyan"), "cyan")
+        coalesce(
+          split(
+            concat_ws(
+              ",",
+              when(col("words").contains("blue"), "blue"),
+              when(col("words").contains("red"), "red"),
+              when(col("words").contains("pink"), "pink"),
+              when(col("words").contains("cyan"), "cyan")
+            ),
+            ","
           ),
-          ","
+          typedLit(Array())
         )
       )
       assertColumnEquality(actualDF, "colors", "expected_colors")

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -241,29 +241,5 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         assertSmallDataFrameEquality(sourceDF, expectedDF, orderedComparison = false)
       }
     }
-
-    "can performed DataFrame comparisons with unordered column" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1, "word"),
-          (5, "word")
-        ),
-        List(
-          ("number", IntegerType, true),
-          ("word", StringType, true)
-        )
-      )
-      val expectedDF = spark.createDF(
-        List(
-          ("word", 1),
-          ("word", 5)
-        ),
-        List(
-          ("word", StringType, true),
-          ("number", IntegerType, true)
-        )
-      )
-      assertLargeDataFrameEquality(sourceDF, expectedDF, ignoreColumnOrder = true)
-    }
   }
 }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -63,7 +63,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
       )
     )
 
-    val e = intercept[DatasetContentMismatch] {
+    intercept[DatasetContentMismatch] {
       assertSmallDataFrameEquality(sourceDF, expectedDF)
     }
   }
@@ -135,7 +135,6 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
   }
 
   "assertSmallDataFrameEquality" - {
-
     "does nothing if the DataFrames have the same schemas and content" in {
       val sourceDF = spark.createDF(
         List(
@@ -175,8 +174,8 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         )
       )
 
-      val _ = intercept[DatasetSchemaMismatch] {
-        assertLargeDataFrameEquality(sourceDF, expectedDF)
+      intercept[DatasetSchemaMismatch] {
+        assertSmallDataFrameEquality(sourceDF, expectedDF)
       }
     }
 
@@ -197,8 +196,8 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         List(("number", IntegerType, true))
       )
 
-      val _ = intercept[DatasetContentMismatch] {
-        assertLargeDataFrameEquality(sourceDF, expectedDF)
+      intercept[DatasetContentMismatch] {
+        assertSmallDataFrameEquality(sourceDF, expectedDF)
       }
     }
 
@@ -236,8 +235,115 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         ),
         List(("number", IntegerType, true))
       )
-      val _ = intercept[DatasetContentMismatch] {
+      intercept[DatasetContentMismatch] {
         assertSmallDataFrameEquality(sourceDF, expectedDF, orderedComparison = false)
+      }
+    }
+  }
+
+  "assertLargeDataFrameEquality" - {
+    "does nothing if the DataFrames have the same schemas and content" in {
+      val sourceDF = spark.createDF(
+        List(
+          (1),
+          (5)
+        ),
+        List(("number", IntegerType, true))
+      )
+
+      val expectedDF = spark.createDF(
+        List(
+          (1),
+          (5)
+        ),
+        List(("number", IntegerType, true))
+      )
+      assertLargeDataFrameEquality(sourceDF, expectedDF)
+    }
+
+    "throws an error if the DataFrames have different schemas" in {
+      val sourceDF = spark.createDF(
+        List(
+          (1),
+          (5)
+        ),
+        List(("number", IntegerType, true))
+      )
+
+      val expectedDF = spark.createDF(
+        List(
+          (1, "word"),
+          (5, "word")
+        ),
+        List(
+          ("number", IntegerType, true),
+          ("word", StringType, true)
+        )
+      )
+
+      intercept[DatasetSchemaMismatch] {
+        assertLargeDataFrameEquality(sourceDF, expectedDF)
+      }
+    }
+
+    "throws an error if the DataFrames content is different" in {
+      val sourceDF = spark.createDF(
+        List(
+          (1),
+          (5)
+        ),
+        List(("number", IntegerType, true))
+      )
+
+      val expectedDF = spark.createDF(
+        List(
+          (10),
+          (5)
+        ),
+        List(("number", IntegerType, true))
+      )
+
+      intercept[DatasetContentMismatch] {
+        assertLargeDataFrameEquality(sourceDF, expectedDF)
+      }
+    }
+
+    "can performed unordered DataFrame comparisons" in {
+      val sourceDF = spark.createDF(
+        List(
+          (1),
+          (5)
+        ),
+        List(("number", IntegerType, true))
+      )
+      val expectedDF = spark.createDF(
+        List(
+          (5),
+          (1)
+        ),
+        List(("number", IntegerType, true))
+      )
+      assertLargeDataFrameEquality(sourceDF, expectedDF, orderedComparison = false)
+    }
+
+    "throws an error for unordered DataFrame comparisons that don't match" in {
+      val sourceDF = spark.createDF(
+        List(
+          (1),
+          (5)
+        ),
+        List(("number", IntegerType, true))
+      )
+      val expectedDF = spark.createDF(
+        List(
+          (5),
+          (1),
+          (10)
+        ),
+        List(("number", IntegerType, true))
+      )
+      intercept[DatasetContentMismatch] {
+        assertLargeDataFrameEquality(sourceDF, expectedDF, orderedComparison = false)
       }
     }
   }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -2,7 +2,6 @@ package com.github.mrpowers.spark.fast.tests
 
 import org.apache.spark.sql.types.{IntegerType, StringType}
 import SparkSessionExt._
-import com.github.mrpowers.spark.fast.tests.SchemaComparer.DatasetSchemaMismatch
 import org.scalatest.freespec.AnyFreeSpec
 
 class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with SparkSessionTestWrapper {

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -134,7 +134,8 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
     assert(e.getMessage.indexOf("jean-claude") >= 0)
   }
 
-  "assertSmallDataFrameEquality" - {
+  "checkingDataFrameEquality" - {
+
     "does nothing if the DataFrames have the same schemas and content" in {
       val sourceDF = spark.createDF(
         List(
@@ -151,6 +152,8 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         ),
         List(("number", IntegerType, true))
       )
+
+      assertSmallDataFrameEquality(sourceDF, expectedDF)
       assertLargeDataFrameEquality(sourceDF, expectedDF)
     }
 
@@ -175,6 +178,9 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
       )
 
       intercept[DatasetSchemaMismatch] {
+        assertLargeDataFrameEquality(sourceDF, expectedDF)
+      }
+      intercept[DatasetSchemaMismatch] {
         assertSmallDataFrameEquality(sourceDF, expectedDF)
       }
     }
@@ -197,9 +203,16 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
       )
 
       intercept[DatasetContentMismatch] {
+        assertLargeDataFrameEquality(sourceDF, expectedDF)
+      }
+      intercept[DatasetContentMismatch] {
         assertSmallDataFrameEquality(sourceDF, expectedDF)
       }
     }
+
+  }
+
+  "assertSmallDataFrameEquality" - {
 
     "can performed unordered DataFrame comparisons" in {
       val sourceDF = spark.createDF(
@@ -239,112 +252,7 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
         assertSmallDataFrameEquality(sourceDF, expectedDF, orderedComparison = false)
       }
     }
+
   }
 
-  "assertLargeDataFrameEquality" - {
-    "does nothing if the DataFrames have the same schemas and content" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1),
-          (5)
-        ),
-        List(("number", IntegerType, true))
-      )
-
-      val expectedDF = spark.createDF(
-        List(
-          (1),
-          (5)
-        ),
-        List(("number", IntegerType, true))
-      )
-      assertLargeDataFrameEquality(sourceDF, expectedDF)
-    }
-
-    "throws an error if the DataFrames have different schemas" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1),
-          (5)
-        ),
-        List(("number", IntegerType, true))
-      )
-
-      val expectedDF = spark.createDF(
-        List(
-          (1, "word"),
-          (5, "word")
-        ),
-        List(
-          ("number", IntegerType, true),
-          ("word", StringType, true)
-        )
-      )
-
-      intercept[DatasetSchemaMismatch] {
-        assertLargeDataFrameEquality(sourceDF, expectedDF)
-      }
-    }
-
-    "throws an error if the DataFrames content is different" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1),
-          (5)
-        ),
-        List(("number", IntegerType, true))
-      )
-
-      val expectedDF = spark.createDF(
-        List(
-          (10),
-          (5)
-        ),
-        List(("number", IntegerType, true))
-      )
-
-      intercept[DatasetContentMismatch] {
-        assertLargeDataFrameEquality(sourceDF, expectedDF)
-      }
-    }
-
-    "can performed unordered DataFrame comparisons" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1),
-          (5)
-        ),
-        List(("number", IntegerType, true))
-      )
-      val expectedDF = spark.createDF(
-        List(
-          (5),
-          (1)
-        ),
-        List(("number", IntegerType, true))
-      )
-      assertLargeDataFrameEquality(sourceDF, expectedDF, orderedComparison = false)
-    }
-
-    "throws an error for unordered DataFrame comparisons that don't match" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1),
-          (5)
-        ),
-        List(("number", IntegerType, true))
-      )
-      val expectedDF = spark.createDF(
-        List(
-          (5),
-          (1),
-          (10)
-        ),
-        List(("number", IntegerType, true))
-      )
-      intercept[DatasetContentMismatch] {
-        assertLargeDataFrameEquality(sourceDF, expectedDF, orderedComparison = false)
-      }
-    }
-  }
 }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -2,10 +2,10 @@ package com.github.mrpowers.spark.fast.tests
 
 import org.apache.spark.sql.types.{IntegerType, StringType}
 import SparkSessionExt._
+import com.github.mrpowers.spark.fast.tests.SchemaComparer.DatasetSchemaMismatch
+import org.scalatest.freespec.AnyFreeSpec
 
-import org.scalatest.FreeSpec
-
-class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSessionTestWrapper {
+class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with SparkSessionTestWrapper {
 
   "prints a descriptive error message if it bugs out" in {
     val sourceDF = spark.createDF(
@@ -135,7 +135,7 @@ class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSe
     assert(e.getMessage.indexOf("jean-claude") >= 0)
   }
 
-  "checkingDataFrameEquality" - {
+  "assertSmallDataFrameEquality" - {
 
     "does nothing if the DataFrames have the same schemas and content" in {
       val sourceDF = spark.createDF(
@@ -153,8 +153,6 @@ class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSe
         ),
         List(("number", IntegerType, true))
       )
-
-      assertSmallDataFrameEquality(sourceDF, expectedDF)
       assertLargeDataFrameEquality(sourceDF, expectedDF)
     }
 
@@ -178,11 +176,8 @@ class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSe
         )
       )
 
-      val e = intercept[DatasetSchemaMismatch] {
+      val _ = intercept[DatasetSchemaMismatch] {
         assertLargeDataFrameEquality(sourceDF, expectedDF)
-      }
-      val e2 = intercept[DatasetSchemaMismatch] {
-        assertSmallDataFrameEquality(sourceDF, expectedDF)
       }
     }
 
@@ -203,17 +198,10 @@ class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSe
         List(("number", IntegerType, true))
       )
 
-      val e = intercept[DatasetContentMismatch] {
+      val _ = intercept[DatasetContentMismatch] {
         assertLargeDataFrameEquality(sourceDF, expectedDF)
       }
-      val e2 = intercept[DatasetContentMismatch] {
-        assertSmallDataFrameEquality(sourceDF, expectedDF)
-      }
     }
-
-  }
-
-  "assertSmallDataFrameEquality" - {
 
     "can performed unordered DataFrame comparisons" in {
       val sourceDF = spark.createDF(
@@ -249,11 +237,33 @@ class DataFrameComparerTest extends FreeSpec with DataFrameComparer with SparkSe
         ),
         List(("number", IntegerType, true))
       )
-      val e = intercept[DatasetContentMismatch] {
+      val _ = intercept[DatasetContentMismatch] {
         assertSmallDataFrameEquality(sourceDF, expectedDF, orderedComparison = false)
       }
     }
 
+    "can performed DataFrame comparisons with unordered column" in {
+      val sourceDF = spark.createDF(
+        List(
+          (1, "word"),
+          (5, "word")
+        ),
+        List(
+          ("number", IntegerType, true),
+          ("word", StringType, true)
+        )
+      )
+      val expectedDF = spark.createDF(
+        List(
+          ("word", 1),
+          ("word", 5)
+        ),
+        List(
+          ("word", StringType, true),
+          ("number", IntegerType, true)
+        )
+      )
+      assertLargeDataFrameEquality(sourceDF, expectedDF, ignoreColumnOrder = true)
+    }
   }
-
 }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -2,7 +2,6 @@ package com.github.mrpowers.spark.fast.tests
 
 import org.apache.spark.sql.types._
 import SparkSessionExt._
-import com.github.mrpowers.spark.fast.tests.SchemaComparer.DatasetSchemaMismatch
 import org.scalatest.freespec.AnyFreeSpec
 
 object Person {

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -341,49 +341,6 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         assertLargeDatasetEquality(sourceDF, expectedDF)
       }
     }
-
-    "can performed DataFrame comparisons with unordered column" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1, "word"),
-          (5, "word")
-        ),
-        List(
-          ("number", IntegerType, true),
-          ("word", StringType, true)
-        )
-      )
-      val expectedDF = spark.createDF(
-        List(
-          ("word", 1),
-          ("word", 5)
-        ),
-        List(
-          ("word", StringType, true),
-          ("number", IntegerType, true)
-        )
-      )
-      assertLargeDatasetEquality(sourceDF, expectedDF, ignoreColumnOrder = true)
-    }
-
-    "can performed Dataset comparisons with unordered column" in {
-      val ds1 = Seq(
-        Person("juan", 5),
-        Person("bob", 1),
-        Person("li", 49),
-        Person("alice", 5)
-      ).toDS
-
-      val ds2 = Seq(
-        Person("juan", 5),
-        Person("bob", 1),
-        Person("li", 49),
-        Person("alice", 5)
-      ).toDS.select("age", "name").as(ds1.encoder)
-
-      assertLargeDatasetEquality(ds1, ds2, ignoreColumnOrder = true)
-      assertLargeDatasetEquality(ds2, ds1, ignoreColumnOrder = true)
-    }
   }
 
   "assertSmallDatasetEquality" - {
@@ -503,50 +460,6 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
         assertSmallDatasetEquality(sourceDF, expectedDF)
       }
     }
-
-    "can performed DataFrame comparisons with unordered column" in {
-      val sourceDF = spark.createDF(
-        List(
-          (1, "word"),
-          (5, "word")
-        ),
-        List(
-          ("number", IntegerType, true),
-          ("word", StringType, true)
-        )
-      )
-      val expectedDF = spark.createDF(
-        List(
-          ("word", 1),
-          ("word", 5)
-        ),
-        List(
-          ("word", StringType, true),
-          ("number", IntegerType, true)
-        )
-      )
-      assertSmallDatasetEquality(sourceDF, expectedDF, ignoreColumnOrder = true)
-    }
-
-    "can performed Dataset comparisons with unordered column" in {
-      val ds1 = Seq(
-        Person("juan", 5),
-        Person("bob", 1),
-        Person("li", 49),
-        Person("alice", 5)
-      ).toDS
-
-      val ds2 = Seq(
-        Person("juan", 5),
-        Person("bob", 1),
-        Person("li", 49),
-        Person("alice", 5)
-      ).toDS.select("age", "name").as(ds1.encoder)
-
-      assertSmallDatasetEquality(ds1, ds2, ignoreColumnOrder = true)
-      assertSmallDatasetEquality(ds2, ds1, ignoreColumnOrder = true)
-    }
-
   }
 
   "defaultSortDataset" - {
@@ -710,23 +623,6 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
 
       assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
     }
-
-    "can work with precision and unordered comparison on nested column" in {
-      import spark.implicits._
-      val ds1 = Seq(
-        ("1", "10/01/2019", 26.762499999999996, Seq(26.762499999999996, 26.762499999999996)),
-        ("1", "11/01/2019", 26.762499999999996, Seq(26.762499999999996, 26.762499999999996))
-      ).toDF("col_B", "col_C", "col_A", "col_D")
-
-      val ds2 = Seq(
-        ("1", "11/01/2019", 26.7624999999999961, Seq(26.7624999999999961, 26.7624999999999961)),
-        ("1", "10/01/2019", 26.762499999999997, Seq(26.762499999999997, 26.762499999999997)),
-      ).toDF("col_B", "col_C", "col_A", "col_D")
-
-
-      assertApproximateDataFrameEquality(ds1, ds2, precision = 0.0000001, orderedComparison = false)
-    }
-
   }
 
 //      "works with FloatType columns" - {

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/RDDComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/RDDComparerTest.scala
@@ -1,8 +1,8 @@
 package com.github.mrpowers.spark.fast.tests
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class RDDComparerTest extends FreeSpec with RDDComparer with SparkSessionTestWrapper {
+class RDDComparerTest extends AnyFreeSpec with RDDComparer with SparkSessionTestWrapper {
 
   "contentMismatchMessage" - {
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/RowComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/RowComparerTest.scala
@@ -1,10 +1,10 @@
 package com.github.mrpowers.spark.fast.tests
 
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 import org.apache.spark.sql.Row
 
-class RowComparerTest extends FreeSpec {
+class RowComparerTest extends AnyFreeSpec {
 
   "areRowsEqual" - {
 
@@ -12,7 +12,7 @@ class RowComparerTest extends FreeSpec {
       val r1 = Row("a", "b")
       val r2 = Row("a", "b")
       assert(
-        RowComparer.areRowsEqual(r1, r2, 0.0) == true
+        RowComparer.areRowsEqual(r1, r2, 0.0)
       )
     }
 
@@ -20,7 +20,7 @@ class RowComparerTest extends FreeSpec {
       val r1 = Row("a", 3)
       val r2 = Row("a", 4)
       assert(
-        RowComparer.areRowsEqual(r1, r2, 0.0) == false
+        !RowComparer.areRowsEqual(r1, r2, 0.0)
       )
     }
 

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
@@ -1,9 +1,9 @@
 package com.github.mrpowers.spark.fast.tests
 
 import org.apache.spark.sql.types._
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class SchemaComparerTest extends FreeSpec {
+class SchemaComparerTest extends AnyFreeSpec {
 
   "equals" - {
 
@@ -126,6 +126,20 @@ class SchemaComparerTest extends FreeSpec {
       assert(SchemaComparer.equals(s1, s2, ignoreColumnNames = true))
     }
 
+    "can ignore the column order when determining equality" in {
+      val s1 = StructType(
+        Seq(
+          StructField("these", StringType, true),
+          StructField("are", StringType, true)
+        )
+      )
+      val s2 = StructType(
+        Seq(
+          StructField("are", StringType, true),
+          StructField("these", StringType, true)
+        )
+      )
+      assert(SchemaComparer.equals(s1, s2))
+    }
   }
-
 }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
@@ -125,21 +125,5 @@ class SchemaComparerTest extends AnyFreeSpec {
       )
       assert(SchemaComparer.equals(s1, s2, ignoreColumnNames = true))
     }
-
-    "can ignore the column order when determining equality" in {
-      val s1 = StructType(
-        Seq(
-          StructField("these", StringType, true),
-          StructField("are", StringType, true)
-        )
-      )
-      val s2 = StructType(
-        Seq(
-          StructField("are", StringType, true),
-          StructField("these", StringType, true)
-        )
-      )
-      assert(SchemaComparer.equals(s1, s2))
-    }
   }
 }

--- a/src/test/scala/com/github/mrpowers/spark/fast/tests/SparkSessionTestWrapper.scala
+++ b/src/test/scala/com/github/mrpowers/spark/fast/tests/SparkSessionTestWrapper.scala
@@ -5,12 +5,14 @@ import org.apache.spark.sql.SparkSession
 trait SparkSessionTestWrapper {
 
   lazy val spark: SparkSession = {
-    SparkSession
+    val session = SparkSession
       .builder()
       .master("local")
       .appName("spark session")
       .config("spark.sql.shuffle.partitions", "1")
       .getOrCreate()
+    session.sparkContext.setLogLevel("ERROR")
+    session
   }
 
 }


### PR DESCRIPTION
Chunked from #122 changes relates to Version Upgrade
Add CI test for spark 3.3 and 3.4
Upgrade scala version to 2.13.13 and 2.11.17
Upgrade Scalatest to 2.13.18
Use more modern sbt syntax
