### PR TITLE
Improve Schema Diff Error Message

### DIFF
--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -71,7 +71,7 @@ Expected DataFrame Row Count: '$expectedCount'
     val e = expectedDS.collect().toSeq
     if (!a.approximateSameElements(e, equals)) {
       val arr = ("Actual Content", "Expected Content")
-      val msg = "Diffs\n" ++ ProductUtil.showProductDiff[T](arr, a, e, truncate)
+      val msg = "Diffs\n" ++ ProductUtil.showProductDiff(arr, a, e, truncate)
       throw DatasetContentMismatch(msg)
     }
   }

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -38,7 +38,7 @@ Expected DataFrame Row Count: '$expectedCount'
   /**
    * Raises an error unless `actualDS` and `expectedDS` are equal
    */
-  def assertSmallDatasetEquality[T](
+  def assertSmallDatasetEquality[T: ClassTag](
       actualDS: Dataset[T],
       expectedDS: Dataset[T],
       ignoreNullable: Boolean = false,
@@ -53,7 +53,7 @@ Expected DataFrame Row Count: '$expectedCount'
     assertSmallDatasetContentEquality(actual, expectedDS, orderedComparison, truncate, equals)
   }
 
-  def assertSmallDatasetContentEquality[T](
+  def assertSmallDatasetContentEquality[T: ClassTag](
       actualDS: Dataset[T],
       expectedDS: Dataset[T],
       orderedComparison: Boolean,
@@ -66,12 +66,12 @@ Expected DataFrame Row Count: '$expectedCount'
       assertSmallDatasetContentEquality(defaultSortDataset(actualDS), defaultSortDataset(expectedDS), truncate, equals)
   }
 
-  def assertSmallDatasetContentEquality[T](actualDS: Dataset[T], expectedDS: Dataset[T], truncate: Int, equals: (T, T) => Boolean): Unit = {
+  def assertSmallDatasetContentEquality[T: ClassTag](actualDS: Dataset[T], expectedDS: Dataset[T], truncate: Int, equals: (T, T) => Boolean): Unit = {
     val a = actualDS.collect().toSeq
     val e = expectedDS.collect().toSeq
     if (!a.approximateSameElements(e, equals)) {
       val arr = ("Actual Content", "Expected Content")
-      val msg = "Diffs\n" ++ DataframeUtil.showDataframeDiff(arr, a.asRows, e.asRows, truncate)
+      val msg = "Diffs\n" ++ ProductUtil.showProductDiff[T](arr, a, e, truncate)
       throw DatasetContentMismatch(msg)
     }
   }

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -10,10 +10,10 @@ import scala.reflect.ClassTag
 object ProductUtil {
   private[mrpowers] def productOrRowToSeq(product: Any): Seq[Any] = {
     product match {
-      case null       => Seq.empty
       case r: Row     => r.toSeq
       case p: Product => p.productIterator.toSeq
-      case _          => throw new IllegalArgumentException("Only Row and Product types are supported")
+      case null       => Seq.empty
+      case s          => Seq(s)
     }
   }
   private[mrpowers] def showProductDiff[T: ClassTag](

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -29,7 +29,7 @@ object ProductUtil {
     val className                        = runTimeClass.getSimpleName
     val border                           = if (runTimeClass == classOf[Row]) ("[", "]") else ("(", ")")
     val prodToString: Seq[Any] => String = s => s.mkString(s"$className${border._1}", ",", border._2)
-    val emptyProd                        = s"$className${border._1}${border._2}"
+    val emptyProd                        = "MISSING"
 
     val sb = new StringBuilder
 

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -1,35 +1,48 @@
 package com.github.mrpowers.spark.fast.tests
 
 import com.github.mrpowers.spark.fast.tests.ufansi.Color.{DarkGray, Green, Red}
+import com.github.mrpowers.spark.fast.tests.ufansi.FansiExtensions.StrOps
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.Row
-import com.github.mrpowers.spark.fast.tests.ufansi.FansiExtensions.StrOps
-object DataframeUtil {
 
-  private[mrpowers] def showDataframeDiff(
+import scala.reflect.ClassTag
+
+object ProductUtil {
+  private[mrpowers] def productOrRowToSeq(product: Any): Seq[Any] = {
+    product match {
+      case null       => Seq.empty
+      case r: Row     => r.toSeq
+      case p: Product => p.productIterator.toSeq
+      case _          => throw new IllegalArgumentException("Only Row and Product types are supported")
+    }
+  }
+  private[mrpowers] def showProductDiff[T: ClassTag](
       header: (String, String),
-      actual: Seq[Row],
-      expected: Seq[Row],
+      actual: Seq[T],
+      expected: Seq[T],
       truncate: Int = 20,
-      minColWidth: Int = 3
+      minColWidth: Int = 3,
+      defaultVal: T = null.asInstanceOf[T],
+      border: (String, String) = ("[", "]")
   ): String = {
+    val className                        = implicitly[ClassTag[T]].runtimeClass.getSimpleName
+    val prodToString: Seq[Any] => String = s => s.mkString(s"$className${border._1}", ",", border._2)
+    val emptyProd                        = s"$className()"
 
     val sb = new StringBuilder
 
-    val fullJoin = actual.zipAll(expected, Row(), Row())
+    val fullJoin = actual.zipAll(expected, defaultVal, defaultVal)
+
     val diff = fullJoin.map { case (actualRow, expectedRow) =>
-      if (equals(actualRow, expectedRow)) {
+      if (actualRow == expectedRow) {
         List(DarkGray(actualRow.toString), DarkGray(expectedRow.toString))
       } else {
-        val actualSeq   = actualRow.toSeq
-        val expectedSeq = expectedRow.toSeq
+        val actualSeq   = productOrRowToSeq(actualRow)
+        val expectedSeq = productOrRowToSeq(expectedRow)
         if (actualSeq.isEmpty)
-          List(
-            Red("[]"),
-            Green(expectedSeq.mkString("[", ",", "]"))
-          )
+          List(Red(emptyProd), Green(prodToString(expectedSeq)))
         else if (expectedSeq.isEmpty)
-          List(Red(actualSeq.mkString("[", ",", "]")), Green("[]"))
+          List(Red(prodToString(actualSeq)), Green(emptyProd))
         else {
           val withEquals = actualSeq
             .zip(expectedSeq)
@@ -38,12 +51,8 @@ object DataframeUtil {
             }
           val allFieldsAreNotEqual = !withEquals.exists(_._3)
           if (allFieldsAreNotEqual) {
-            List(
-              Red(actualSeq.mkString("[", ",", "]")),
-              Green(expectedSeq.mkString("[", ",", "]"))
-            )
+            List(Red(prodToString(actualSeq)), Green(prodToString(expectedSeq)))
           } else {
-
             val coloredDiff = withEquals
               .map {
                 case (actualRowField, expectedRowField, true) =>
@@ -51,9 +60,9 @@ object DataframeUtil {
                 case (actualRowField, expectedRowField, false) =>
                   (Red(actualRowField.toString), Green(expectedRowField.toString))
               }
-            val start = DarkGray("[")
+            val start = DarkGray(s"$className${border._1}")
             val sep   = DarkGray(",")
-            val end   = DarkGray("]")
+            val end   = DarkGray(border._2)
             List(
               coloredDiff.map(_._1).mkStr(start, sep, end),
               coloredDiff.map(_._2).mkStr(start, sep, end)
@@ -69,11 +78,12 @@ object DataframeUtil {
     val colWidths = Array.fill(numCols)(minColWidth)
 
     // Compute the width of each column
-    for ((cell, i) <- headerSeq.zipWithIndex) {
+    headerSeq.zipWithIndex.foreach({ case (cell, i) =>
       colWidths(i) = math.max(colWidths(i), cell.length)
-    }
-    for (row <- diff) {
-      for ((cell, i) <- row.zipWithIndex) {
+    })
+
+    diff.foreach { row =>
+      row.zipWithIndex.foreach { case (cell, i) =>
         colWidths(i) = math.max(colWidths(i), cell.length)
       }
     }
@@ -117,5 +127,4 @@ object DataframeUtil {
 
     sb.toString
   }
-
 }

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -10,10 +10,12 @@ import scala.reflect.ClassTag
 object ProductUtil {
   private[mrpowers] def productOrRowToSeq(product: Any): Seq[Any] = {
     product match {
-      case null       => Seq.empty
-      case r: Row     => r.toSeq
-      case p: Product => p.productIterator.toSeq
-      case s          => Seq(s)
+      case null           => Seq.empty
+      case a: Array[_]    => a
+      case i: Iterable[_] => i.toSeq
+      case r: Row         => r.toSeq
+      case p: Product     => p.productIterator.toSeq
+      case s              => Seq(s)
     }
   }
   private[mrpowers] def showProductDiff[T: ClassTag](
@@ -45,7 +47,7 @@ object ProductUtil {
           List(Red(prodToString(actualSeq)), Green(emptyProd))
         else {
           val withEquals = actualSeq
-            .zip(expectedSeq)
+            .zipAll(expectedSeq, "MISSING", "MISSING")
             .map { case (actualRowField, expectedRowField) =>
               (actualRowField, expectedRowField, actualRowField == expectedRowField)
             }

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -10,9 +10,9 @@ import scala.reflect.ClassTag
 object ProductUtil {
   private[mrpowers] def productOrRowToSeq(product: Any): Seq[Any] = {
     product match {
+      case null       => Seq.empty
       case r: Row     => r.toSeq
       case p: Product => p.productIterator.toSeq
-      case null       => Seq.empty
       case s          => Seq(s)
     }
   }
@@ -22,7 +22,6 @@ object ProductUtil {
       expected: Seq[T],
       truncate: Int = 20,
       minColWidth: Int = 3,
-      defaultVal: T = null.asInstanceOf[T]
   ): String = {
 
     val runTimeClass                     = implicitly[ClassTag[T]].runtimeClass
@@ -32,7 +31,7 @@ object ProductUtil {
 
     val sb = new StringBuilder
 
-    val fullJoin = actual.zipAll(expected, defaultVal, defaultVal)
+    val fullJoin = actual.zipAll(expected, null, null)
 
     val diff = fullJoin.map { case (actualRow, expectedRow) =>
       if (actualRow == expectedRow) {

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -21,7 +21,7 @@ object ProductUtil {
       actual: Seq[T],
       expected: Seq[T],
       truncate: Int = 20,
-      minColWidth: Int = 3,
+      minColWidth: Int = 3
   ): String = {
 
     val runTimeClass                     = implicitly[ClassTag[T]].runtimeClass

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -26,9 +26,8 @@ object ProductUtil {
   ): String = {
 
     val runTimeClass                     = implicitly[ClassTag[T]].runtimeClass
-    val className                        = runTimeClass.getSimpleName
-    val border                           = if (runTimeClass == classOf[Row]) ("[", "]") else ("(", ")")
-    val prodToString: Seq[Any] => String = s => s.mkString(s"$className${border._1}", ",", border._2)
+    val (className, lBracket, rBracket)  = if (runTimeClass == classOf[Row]) ("", "[", "]") else (runTimeClass.getSimpleName, "(", ")")
+    val prodToString: Seq[Any] => String = s => s.mkString(s"$className$lBracket", ",", rBracket)
     val emptyProd                        = "MISSING"
 
     val sb = new StringBuilder
@@ -62,9 +61,9 @@ object ProductUtil {
                 case (actualRowField, expectedRowField, false) =>
                   (Red(actualRowField.toString), Green(expectedRowField.toString))
               }
-            val start = DarkGray(s"$className${border._1}")
+            val start = DarkGray(s"$className$lBracket")
             val sep   = DarkGray(",")
-            val end   = DarkGray(border._2)
+            val end   = DarkGray(rBracket)
             List(
               coloredDiff.map(_._1).mkStr(start, sep, end),
               coloredDiff.map(_._2).mkStr(start, sep, end)

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -22,12 +22,14 @@ object ProductUtil {
       expected: Seq[T],
       truncate: Int = 20,
       minColWidth: Int = 3,
-      defaultVal: T = null.asInstanceOf[T],
-      border: (String, String) = ("[", "]")
+      defaultVal: T = null.asInstanceOf[T]
   ): String = {
-    val className                        = implicitly[ClassTag[T]].runtimeClass.getSimpleName
+
+    val runTimeClass                     = implicitly[ClassTag[T]].runtimeClass
+    val className                        = runTimeClass.getSimpleName
+    val border                           = if (runTimeClass == classOf[Row]) ("[", "]") else ("(", ")")
     val prodToString: Seq[Any] => String = s => s.mkString(s"$className${border._1}", ",", border._2)
-    val emptyProd                        = s"$className()"
+    val emptyProd                        = s"$className${border._1}${border._2}"
 
     val sb = new StringBuilder
 

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
@@ -11,8 +11,7 @@ object SchemaComparer {
       ("Actual Schema", "Expected Schema"),
       actualDS.schema.fields,
       expectedDS.schema.fields,
-      truncate = 200,
-      defaultVal = StructField("SPARK_FAST_TEST_MISSING_FIELD", NullType)
+      truncate = 200
     )
   }
 

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
@@ -12,8 +12,7 @@ object SchemaComparer {
       actualDS.schema.fields,
       expectedDS.schema.fields,
       truncate = 200,
-      defaultVal = StructField("SPARK_FAST_TEST_MISSING_FIELD", NullType),
-      border = ("(", ")")
+      defaultVal = StructField("SPARK_FAST_TEST_MISSING_FIELD", NullType)
     )
   }
 

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -74,8 +74,8 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
     val colourGroup         = e.getMessage.extractColorGroup
     val expectedColourGroup = colourGroup.get(Console.GREEN)
     val actualColourGroup   = colourGroup.get(Console.RED)
-    assert(expectedColourGroup.contains(Seq("uk", "Row[steve,10,aus]")))
-    assert(actualColourGroup.contains(Seq("france", "Row[mark,11,usa]")))
+    assert(expectedColourGroup.contains(Seq("uk", "[steve,10,aus]")))
+    assert(actualColourGroup.contains(Seq("france", "[mark,11,usa]")))
   }
 
   "works well for wide DataFrames" in {

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -74,8 +74,8 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
     val colourGroup         = e.getMessage.extractColorGroup
     val expectedColourGroup = colourGroup.get(Console.GREEN)
     val actualColourGroup   = colourGroup.get(Console.RED)
-    assert(expectedColourGroup.contains(Seq("uk", "[steve,10,aus]")))
-    assert(actualColourGroup.contains(Seq("france", "[mark,11,usa]")))
+    assert(expectedColourGroup.contains(Seq("uk", "Row[steve,10,aus]")))
+    assert(actualColourGroup.contains(Seq("france", "Row[mark,11,usa]")))
   }
 
   "works well for wide DataFrames" in {

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -153,13 +153,12 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
       val e = intercept[DatasetContentMismatch] {
         assertSmallDatasetEquality(sourceDS, expectedDS)
       }
-      println(e)
 
       val colourGroup         = e.getMessage.extractColorGroup
       val expectedColourGroup = colourGroup.get(Console.GREEN)
       val actualColourGroup   = colourGroup.get(Console.RED)
-      assert(expectedColourGroup.contains(Seq("(apple, banana1)")))
-      assert(actualColourGroup.contains(Seq("(apple, banana)")))
+      assert(expectedColourGroup.contains(Seq("(apple,banana1)")))
+      assert(actualColourGroup.contains(Seq("(apple,banana)")))
     }
 
     "works with really long columns" in {

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -81,8 +81,8 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
       val colourGroup         = e.getMessage.extractColorGroup
       val expectedColourGroup = colourGroup.get(Console.GREEN)
       val actualColourGroup   = colourGroup.get(Console.RED)
-      assert(expectedColourGroup.contains(Seq("StructField(long,LongType2,true,{})")))
-      assert(actualColourGroup.contains(Seq("StructField(long,LongType,true,{})")))
+      assert(expectedColourGroup.contains(Seq("String(StructField(long,LongType2,true,{}))")))
+      assert(actualColourGroup.contains(Seq("String(StructField(long,LongType,true,{}))")))
     }
 
     "correctly mark unequal element for Dataset[Seq[String]]" in {

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -62,8 +62,8 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
       val colourGroup         = e.getMessage.extractColorGroup
       val expectedColourGroup = colourGroup.get(Console.GREEN)
       val actualColourGroup   = colourGroup.get(Console.RED)
-      assert(expectedColourGroup.contains(Seq("[frank,10]", "lucy")))
-      assert(actualColourGroup.contains(Seq("[bob,1]", "alice")))
+      assert(expectedColourGroup.contains(Seq("Person(frank,10)", "lucy")))
+      assert(actualColourGroup.contains(Seq("Person(bob,1)", "alice")))
     }
 
     "works with really long columns" in {

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -154,31 +154,70 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
     }
 
     "throws an error if the DataFrames have different schemas" in {
+      val nestedSchema = StructType(
+        Seq(
+          StructField(
+            "attributes",
+            StructType(
+              Seq(
+                StructField("PostCode", IntegerType, nullable = true)
+              )
+            ),
+            nullable = true
+          )
+        )
+      )
+
+      val nestedSchema2 = StructType(
+        Seq(
+          StructField(
+            "attributes",
+            StructType(
+              Seq(
+                StructField("PostCode", StringType, nullable = true)
+              )
+            ),
+            nullable = true
+          )
+        )
+      )
+
       val sourceDF = spark.createDF(
         List(
-          (1),
-          (5)
+          (1, 2.0, null),
+          (5, 3.0, null)
         ),
-        List(("number", IntegerType, true))
+        List(
+          ("number", IntegerType, true),
+          ("float", DoubleType, true),
+          ("nestedField", nestedSchema, true)
+        )
       )
 
       val expectedDF = spark.createDF(
         List(
-          (1, "word"),
-          (5, "word")
+          (1, "word", null, 1L),
+          (5, "word", null, 2L)
         ),
         List(
           ("number", IntegerType, true),
-          ("word", StringType, true)
+          ("word", StringType, true),
+          ("nestedField", nestedSchema2, true),
+          ("long", LongType, true)
         )
       )
 
       val e = intercept[DatasetSchemaMismatch] {
         assertLargeDatasetEquality(sourceDF, expectedDF)
       }
+      println(e)
       val e2 = intercept[DatasetSchemaMismatch] {
         assertSmallDatasetEquality(sourceDF, expectedDF)
       }
+      println(e2)
+
+      sourceDF.schema.printTreeString()
+      expectedDF.schema.printTreeString()
     }
 
     "throws an error if the DataFrames content is different" in {


### PR DESCRIPTION
What changed:
- Improve Schema Diff Error message with color on different element
- Fix Dataset content color diff to properly display for Dataset[Array[_]] cases
- Display diff for each element of Dataset[Iterable[_]] cases

Schema Diff before:

![image](https://github.com/user-attachments/assets/7bfb91c9-f3bf-400e-b132-93e7c4cc7536)

Schema Diff now:

![image](https://github.com/user-attachments/assets/37b836ac-d564-4cf8-85b6-1de40c5c98b7)

Dispaly for Dataframe diff

![image](https://github.com/user-attachments/assets/04ed75d2-5ed8-4cee-bbc4-f958e8f2f27c)

Display for Dataset diff

![image](https://github.com/user-attachments/assets/34a0e48f-6150-475c-b16d-d501d7e1012d)
