### PR TITLE
Add tree-string color diff

### DIFF
--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/DatasetComparer.scala
@@ -3,8 +3,8 @@ package com.github.mrpowers.spark.fast.tests
 import com.github.mrpowers.spark.fast.tests.DatasetComparer.maxUnequalRowsToShow
 import com.github.mrpowers.spark.fast.tests.SeqLikesExtensions.SeqExtensions
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
 
 import scala.reflect.ClassTag
 
@@ -49,7 +49,7 @@ Expected DataFrame Row Count: '$expectedCount'
       truncate: Int = 500,
       equals: (T, T) => Boolean = (o1: T, o2: T) => o1.equals(o2)
   ): Unit = {
-    SchemaComparer.assertSchemaEqual(actualDS, expectedDS, ignoreNullable, ignoreColumnNames, ignoreColumnOrder, ignoreMetadata)
+    SchemaComparer.assertDatasetSchemaEqual(actualDS, expectedDS, ignoreNullable, ignoreColumnNames, ignoreColumnOrder, ignoreMetadata)
     val actual = if (ignoreColumnOrder) orderColumns(actualDS, expectedDS) else actualDS
     assertSmallDatasetContentEquality(actual, expectedDS, orderedComparison, truncate, equals)
   }
@@ -103,7 +103,7 @@ Expected DataFrame Row Count: '$expectedCount'
       ignoreMetadata: Boolean = true
   ): Unit = {
     // first check if the schemas are equal
-    SchemaComparer.assertSchemaEqual(actualDS, expectedDS, ignoreNullable, ignoreColumnNames, ignoreColumnOrder, ignoreMetadata)
+    SchemaComparer.assertDatasetSchemaEqual(actualDS, expectedDS, ignoreNullable, ignoreColumnNames, ignoreColumnOrder, ignoreMetadata)
     val actual = if (ignoreColumnOrder) orderColumns(actualDS, expectedDS) else actualDS
     assertLargeDatasetContentEquality(actual, expectedDS, equals, orderedComparison)
   }

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
@@ -7,6 +7,8 @@ import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types._
 
 object SchemaComparer {
+  private val INDENT_GAP      = 5
+  private val DESCRIPTION_GAP = 21
   case class DatasetSchemaMismatch(smth: String) extends Exception(smth)
   private def betterSchemaMismatchMessage(actualSchema: StructType, expectedSchema: StructType): String = {
     showProductDiff(
@@ -20,8 +22,7 @@ object SchemaComparer {
   private def treeSchemaMismatchMessage[T](actualSchema: StructType, expectedSchema: StructType): String = {
     def flattenStrucType(s: StructType, indent: Int): (Seq[(Int, StructField)], Int) = s
       .foldLeft((Seq.empty[(Int, StructField)], Int.MinValue)) { case ((fieldPair, maxWidth), f) =>
-        // 5 char for each level of indentation, 21 char for gap, and description words
-        val gap         = indent * 5 + 21 + f.name.length + f.dataType.typeName.length + f.nullable.toString.length
+        val gap         = indent * INDENT_GAP + DESCRIPTION_GAP + f.name.length + f.dataType.typeName.length + f.nullable.toString.length
         val pair        = fieldPair :+ (indent, f)
         val newMaxWidth = scala.math.max(maxWidth, gap)
         f.dataType match {

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
@@ -9,6 +9,7 @@ import org.apache.spark.sql.types._
 object SchemaComparer {
   private val INDENT_GAP      = 5
   private val DESCRIPTION_GAP = 21
+  private val TREE_GAP        = 6
   case class DatasetSchemaMismatch(smth: String) extends Exception(smth)
   private def betterSchemaMismatchMessage(actualSchema: StructType, expectedSchema: StructType): String = {
     showProductDiff(
@@ -34,7 +35,6 @@ object SchemaComparer {
       }
 
     def depthToIndentStr(depth: Int): String = Range(0, depth).map(_ => "|    ").mkString + "|--"
-    val treeSpaces                           = 6
     val (treeFieldPair1, tree1MaxWidth)      = flattenStrucType(actualSchema, 0)
     val (treeFieldPair2, _)                  = flattenStrucType(expectedSchema, 0)
     val (treePair, maxWidth) = treeFieldPair1
@@ -89,8 +89,8 @@ object SchemaComparer {
         (acc :+ pair, math.max(maxWidth, pair._1.length))
       }
 
-    val schemaGap = maxWidth + treeSpaces
-    val headerGap = tree1MaxWidth + treeSpaces
+    val schemaGap = maxWidth + TREE_GAP
+    val headerGap = tree1MaxWidth + TREE_GAP
     treePair
       .foldLeft(new StringBuilder("\nActual Schema".padTo(headerGap, ' ') + "Expected Schema\n")) { case (sb, (s1, s2)) =>
         val gap = if (s1.isEmpty) headerGap else schemaGap

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
@@ -34,7 +34,7 @@ object SchemaComparer {
 
     def depthToIndentStr(depth: Int): String = Range(0, depth).map(_ => "|    ").mkString + "|--"
     val treeSpaces                           = 6
-    val (treeFieldPair1, headerGap)          = flattenStrucType(actualSchema, 0)
+    val (treeFieldPair1, tree1MaxWidth)      = flattenStrucType(actualSchema, 0)
     val (treeFieldPair2, _)                  = flattenStrucType(expectedSchema, 0)
     val (treePair, maxWidth) = treeFieldPair1
       .zipAll(treeFieldPair2, (0, null), (0, null))
@@ -74,14 +74,14 @@ object SchemaComparer {
             val name     = Red(field1.name)
             val dtype    = Red(field1.dataType.typeName)
             val nullable = Red(field1.nullable.toString)
-            s"$prefix1 $name : $dtype (nullable = $nullable)"
+            s"$sprefix1 $name : $dtype (nullable = $nullable)"
           } else ""
 
           val structString2 = if (field2 != null) {
             val name     = Green(field2.name)
             val dtype    = Green(field2.dataType.typeName)
             val nullable = Green(field2.nullable.toString)
-            s"$prefix2 $name : $dtype (nullable = $nullable)"
+            s"$sprefix2 $name : $dtype (nullable = $nullable)"
           } else ""
           (structString1, structString2)
         }
@@ -89,10 +89,12 @@ object SchemaComparer {
       }
 
     val schemaGap = maxWidth + treeSpaces
+    val headerGap = tree1MaxWidth + treeSpaces
     treePair
       .foldLeft(new StringBuilder("\nActual Schema".padTo(headerGap, ' ') + "Expected Schema\n")) { case (sb, (s1, s2)) =>
         val gap = if (s1.isEmpty) headerGap else schemaGap
-        sb.append(s1.padTo(gap, ' ') + s2 + "\n")
+        val s   = if (s2.isEmpty) s1 else s1.padTo(gap, ' ')
+        sb.append(s + s2 + "\n")
       }
       .toString()
   }

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaComparer.scala
@@ -1,8 +1,9 @@
 package com.github.mrpowers.spark.fast.tests
 
 import com.github.mrpowers.spark.fast.tests.ProductUtil.showProductDiff
+import com.github.mrpowers.spark.fast.tests.ufansi.Color.{DarkGray, Green, Red}
 import org.apache.spark.sql.Dataset
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, NullType, StructField, StructType}
+import org.apache.spark.sql.types._
 
 object SchemaComparer {
   case class DatasetSchemaMismatch(smth: String) extends Exception(smth)
@@ -15,7 +16,85 @@ object SchemaComparer {
     )
   }
 
-  def assertSchemaEqual[T](
+  private def treeSchemaMismatchMessage[T](actualSchema: StructType, expectedSchema: StructType): String = {
+    def flattenStrucType(s: StructType, indent: Int): List[(Int, Int, StructField)] = s
+      .foldLeft(List.empty[(Int, Int, StructField)]) { case (fieldPair, f) =>
+        // 5 char for each level of indentation, 21 char for gap, and description words
+        val gap  = indent * 5 + 21 + f.name.length + f.dataType.typeName.length + f.nullable.toString.length
+        val pair = fieldPair :+ (indent, gap, f)
+        f.dataType match {
+          case st: StructType => pair ++ flattenStrucType(st, indent + 1)
+          case _              => pair
+        }
+      }
+
+    def depthToIndentStr(depth: Int): String = Range(0, depth).map(_ => "|    ").mkString + "|--"
+    val treeSpaces                           = 6
+    val treeFieldPair1                       = flattenStrucType(actualSchema, 0)
+    val treeFieldPair2                       = flattenStrucType(expectedSchema, 0)
+    val headerGap                            = treeFieldPair1.groupBy(_._2).maxBy(_._1)._1 + treeSpaces
+    val treePair = treeFieldPair1
+      .zipAll(treeFieldPair2, (0, 0, null), (0, 0, null))
+      .map { case ((indent1, _, field1), (indent2, _, field2)) =>
+        val prefix1 = depthToIndentStr(indent1)
+        val prefix2 = depthToIndentStr(indent2)
+        val (sprefix1, sprefix2) = if (indent1 != indent2) {
+          (Red(prefix1), Green(prefix2))
+        } else {
+          (DarkGray(prefix1), DarkGray(prefix2))
+        }
+
+        if (field1 != null && field2 != null) {
+          val (name1, name2) =
+            if (field1.name != field2.name)
+              (Red(field1.name), Green(field2.name))
+            else
+              (DarkGray(field1.name), DarkGray(field2.name))
+
+          val (dtype1, dtype2) =
+            if (field1.dataType != field2.dataType)
+              (Red(field1.dataType.typeName), Green(field2.dataType.typeName))
+            else
+              (DarkGray(field1.dataType.typeName), DarkGray(field2.dataType.typeName))
+
+          val (nullable1, nullable2) =
+            if (field1.nullable != field2.nullable)
+              (Red(field1.nullable.toString), Green(field2.nullable.toString))
+            else
+              (DarkGray(field1.nullable.toString), DarkGray(field2.nullable.toString))
+
+          val structString1 = s"$sprefix1 $name1 : $dtype1 (nullable = $nullable1)"
+          val structString2 = s"$sprefix2 $name2 : $dtype2 (nullable = $nullable2)"
+          (structString1, structString2)
+        } else {
+          val structString1 = if (field1 != null) {
+            val name     = Red(field1.name)
+            val dtype    = Red(field1.dataType.typeName)
+            val nullable = Red(field1.nullable.toString)
+            s"$prefix1 $name : $dtype (nullable = $nullable)"
+          } else ""
+
+          val structString2 = if (field2 != null) {
+            val name     = Green(field2.name)
+            val dtype    = Green(field2.dataType.typeName)
+            val nullable = Green(field2.nullable.toString)
+            s"$prefix2 $name : $dtype (nullable = $nullable)"
+          } else ""
+          (structString1, structString2)
+        }
+      }
+
+    val schemaGap = treePair.groupBy(_._1.length).maxBy(_._1)._1 + treeSpaces
+
+    treePair
+      .foldLeft(new StringBuilder("\nActual Schema".padTo(headerGap, ' ') + "Expected Schema\n")) { case (sb, (s1, s2)) =>
+        val gap = if (s1.isEmpty) headerGap else schemaGap
+        sb.append(s1.padTo(gap, ' ') + s2 + "\n")
+      }
+      .toString()
+  }
+
+  def assertDatasetSchemaEqual[T](
       actualDS: Dataset[T],
       expectedDS: Dataset[T],
       ignoreNullable: Boolean = false,
@@ -23,10 +102,21 @@ object SchemaComparer {
       ignoreColumnOrder: Boolean = true,
       ignoreMetadata: Boolean = true
   ): Unit = {
+    assertSchemaEqual(actualDS.schema, expectedDS.schema, ignoreNullable, ignoreColumnNames, ignoreColumnOrder, ignoreMetadata)
+  }
+
+  def assertSchemaEqual(
+      actualSchema: StructType,
+      expectedSchema: StructType,
+      ignoreNullable: Boolean = false,
+      ignoreColumnNames: Boolean = false,
+      ignoreColumnOrder: Boolean = true,
+      ignoreMetadata: Boolean = true
+  ): Unit = {
     require((ignoreColumnNames, ignoreColumnOrder) != (true, true), "Cannot set both ignoreColumnNames and ignoreColumnOrder to true.")
-    if (!SchemaComparer.equals(actualDS.schema, expectedDS.schema, ignoreNullable, ignoreColumnNames, ignoreColumnOrder, ignoreMetadata)) {
+    if (!SchemaComparer.equals(actualSchema, expectedSchema, ignoreNullable, ignoreColumnNames, ignoreColumnOrder, ignoreMetadata)) {
       throw DatasetSchemaMismatch(
-        "Diffs\n" + betterSchemaMismatchMessage(actualDS, expectedDS)
+        "Diffs\n" + treeSchemaMismatchMessage(actualSchema, expectedSchema)
       )
     }
   }

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaDiffOutputFormat.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/SchemaDiffOutputFormat.scala
@@ -1,0 +1,7 @@
+package com.github.mrpowers.spark.fast.tests
+
+object SchemaDiffOutputFormat extends Enumeration {
+  type SchemaDiffOutputFormat = Value
+
+  val Tree, Table = Value
+}

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
@@ -243,7 +243,7 @@ class SchemaComparerTest extends AnyFreeSpec {
       assert(SchemaComparer.equals(s1, s2))
     }
 
-    "display schema diff as tree" in {
+    "display schema diff as tree with different depth" in {
       val s1 = StructType(
         Seq(
           StructField("array", ArrayType(StringType, containsNull = true), true),
@@ -308,7 +308,7 @@ class SchemaComparerTest extends AnyFreeSpec {
       }
       val expectedMessage = """Diffs
           |
-          |Actual Schema                                      Expected Schema
+          |Actual Schema                                            Expected Schema
           |\u001b[90m|--\u001b[39m \u001b[90marray\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                       \u001b[90m|--\u001b[39m \u001b[90marray\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
           |\u001b[90m|--\u001b[39m \u001b[31mmap\u001b[39m : \u001b[31mmap\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                           \u001b[90m|--\u001b[39m \u001b[32msomething\u001b[39m : \u001b[32mstring\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
           |\u001b[90m|--\u001b[39m \u001b[31msomething\u001b[39m : \u001b[31mstring\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                  \u001b[90m|--\u001b[39m \u001b[32mmap\u001b[39m : \u001b[32mmap\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
@@ -319,6 +319,235 @@ class SchemaComparerTest extends AnyFreeSpec {
           |\u001b[90m|    |    |--\u001b[39m \u001b[31mmood2\u001b[39m : \u001b[31marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)             \u001b[90m|    |    |--\u001b[39m \u001b[32mmood3\u001b[39m : \u001b[32marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
           |\u001b[31m|    |    |--\u001b[39m \u001b[31msomething2\u001b[39m : \u001b[90mstring\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)      \u001b[32m|--\u001b[39m \u001b[32mnorma2\u001b[39m : \u001b[90mstring\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)
           |""".stripMargin
+
+      assert(e.getMessage == expectedMessage)
+    }
+
+    "display schema diff for wide tree" in {
+      val s1 = StructType(
+        Seq(
+          StructField("array", ArrayType(StringType, containsNull = true), true),
+          StructField("map", MapType(StringType, StringType, valueContainsNull = false), true),
+          StructField("something", StringType, true),
+          StructField(
+            "struct",
+            StructType(
+              StructType(
+                Seq(
+                  StructField("mood", ArrayType(StringType, containsNull = false), true),
+                  StructField("something", StringType, false),
+                  StructField(
+                    "something2",
+                    StructType(
+                      Seq(
+                        StructField("mood2", ArrayType(DoubleType, containsNull = false), true),
+                        StructField(
+                          "something2",
+                          StructType(
+                            Seq(
+                              StructField("mood", ArrayType(StringType, containsNull = false), true),
+                              StructField("something", StringType, false),
+                              StructField(
+                                "something2",
+                                StructType(
+                                  Seq(
+                                    StructField("mood2", ArrayType(DoubleType, containsNull = false), true),
+                                    StructField("something2", StringType, false)
+                                  )
+                                ),
+                                false
+                              )
+                            )
+                          ),
+                          false
+                        )
+                      )
+                    ),
+                    false
+                  )
+                )
+              )
+            ),
+            true
+          )
+        )
+      )
+      val s2 = StructType(
+        Seq(
+          StructField("array", ArrayType(StringType, containsNull = true), true),
+          StructField("something", StringType, true),
+          StructField("map", MapType(StringType, StringType, valueContainsNull = false), true),
+          StructField(
+            "struct",
+            StructType(
+              StructType(
+                Seq(
+                  StructField("something", StringType, false),
+                  StructField("mood", ArrayType(StringType, containsNull = false), true),
+                  StructField(
+                    "something3",
+                    StructType(
+                      Seq(
+                        StructField("mood2", ArrayType(DoubleType, containsNull = false), true),
+                        StructField(
+                          "something2",
+                          StructType(
+                            Seq(
+                              StructField("mood", ArrayType(StringType, containsNull = false), true),
+                              StructField("something", StringType, false),
+                              StructField(
+                                "something2",
+                                StructType(
+                                  Seq(
+                                    StructField("mood2", ArrayType(DoubleType, containsNull = false), true),
+                                    StructField("something2", StringType, false)
+                                  )
+                                ),
+                                false
+                              )
+                            )
+                          ),
+                          false
+                        )
+                      )
+                    ),
+                    false
+                  )
+                )
+              )
+            ),
+            true
+          ),
+          StructField("norma2", StringType, false)
+        )
+      )
+
+      val e = intercept[DatasetSchemaMismatch] {
+        SchemaComparer.assertSchemaEqual(s1, s2, ignoreColumnOrder = false, outputFormat = SchemaDiffOutputFormat.Tree)
+      }
+      val expectedMessage = """Diffs
+          |
+          |Actual Schema                                                      Expected Schema
+          |\u001b[90m|--\u001b[39m \u001b[90marray\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                                 \u001b[90m|--\u001b[39m \u001b[90marray\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|--\u001b[39m \u001b[31mmap\u001b[39m : \u001b[31mmap\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                                     \u001b[90m|--\u001b[39m \u001b[32msomething\u001b[39m : \u001b[32mstring\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|--\u001b[39m \u001b[31msomething\u001b[39m : \u001b[31mstring\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                            \u001b[90m|--\u001b[39m \u001b[32mmap\u001b[39m : \u001b[32mmap\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|--\u001b[39m \u001b[90mstruct\u001b[39m : \u001b[31mstruct\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                               \u001b[90m|--\u001b[39m \u001b[90mstruct\u001b[39m : \u001b[32mstruct\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|    |--\u001b[39m \u001b[31mmood\u001b[39m : \u001b[31marray\u001b[39m (nullable = \u001b[31mtrue\u001b[39m)                             \u001b[90m|    |--\u001b[39m \u001b[32msomething\u001b[39m : \u001b[32mstring\u001b[39m (nullable = \u001b[32mfalse\u001b[39m)
+          |\u001b[90m|    |--\u001b[39m \u001b[31msomething\u001b[39m : \u001b[31mstring\u001b[39m (nullable = \u001b[31mfalse\u001b[39m)                      \u001b[90m|    |--\u001b[39m \u001b[32mmood\u001b[39m : \u001b[32marray\u001b[39m (nullable = \u001b[32mtrue\u001b[39m)
+          |\u001b[90m|    |--\u001b[39m \u001b[31msomething2\u001b[39m : \u001b[90mstruct\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)                     \u001b[90m|    |--\u001b[39m \u001b[32msomething3\u001b[39m : \u001b[90mstruct\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)
+          |\u001b[90m|    |    |--\u001b[39m \u001b[90mmood2\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                       \u001b[90m|    |    |--\u001b[39m \u001b[90mmood2\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|    |    |--\u001b[39m \u001b[90msomething2\u001b[39m : \u001b[90mstruct\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)                \u001b[90m|    |    |--\u001b[39m \u001b[90msomething2\u001b[39m : \u001b[90mstruct\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)
+          |\u001b[90m|    |    |    |--\u001b[39m \u001b[90mmood\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                   \u001b[90m|    |    |    |--\u001b[39m \u001b[90mmood\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|    |    |    |--\u001b[39m \u001b[90msomething\u001b[39m : \u001b[90mstring\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)            \u001b[90m|    |    |    |--\u001b[39m \u001b[90msomething\u001b[39m : \u001b[90mstring\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)
+          |\u001b[90m|    |    |    |--\u001b[39m \u001b[90msomething2\u001b[39m : \u001b[90mstruct\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)           \u001b[90m|    |    |    |--\u001b[39m \u001b[90msomething2\u001b[39m : \u001b[90mstruct\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)
+          |\u001b[90m|    |    |    |    |--\u001b[39m \u001b[90mmood2\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)             \u001b[90m|    |    |    |    |--\u001b[39m \u001b[90mmood2\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|    |    |    |    |--\u001b[39m \u001b[90msomething2\u001b[39m : \u001b[90mstring\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)      \u001b[90m|    |    |    |    |--\u001b[39m \u001b[90msomething2\u001b[39m : \u001b[90mstring\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)
+          |                                                                    \u001b[90m|--\u001b[39m \u001b[32mnorma2\u001b[39m : \u001b[32mstring\u001b[39m (nullable = \u001b[32mfalse\u001b[39m)
+          |""".stripMargin
+
+      assert(e.getMessage == expectedMessage)
+    }
+
+    "display schema diff as tree with more actual Column 2" in {
+      val s1 = StructType(
+        Seq(
+          StructField("array", ArrayType(StringType, containsNull = true), true),
+          StructField("map", MapType(StringType, StringType, valueContainsNull = false), true),
+          StructField("something", StringType, true),
+          StructField(
+            "struct",
+            StructType(
+              StructType(
+                Seq(
+                  StructField("mood", ArrayType(StringType, containsNull = false), true),
+                  StructField("something", StringType, false),
+                  StructField(
+                    "something2",
+                    StructType(
+                      Seq(
+                        StructField("mood2", ArrayType(DoubleType, containsNull = false), true),
+                        StructField(
+                          "something2",
+                          StructType(
+                            Seq(
+                              StructField("mood2", ArrayType(DoubleType, containsNull = false), true),
+                              StructField(
+                                "something2",
+                                StructType(
+                                  Seq(
+                                    StructField("mood2", ArrayType(DoubleType, containsNull = false), true),
+                                    StructField("something2", StringType, false)
+                                  )
+                                ),
+                                false
+                              )
+                            )
+                          ),
+                          false
+                        )
+                      )
+                    ),
+                    false
+                  )
+                )
+              )
+            ),
+            true
+          )
+        )
+      )
+      val s2 = StructType(
+        Seq(
+          StructField("array", ArrayType(StringType, containsNull = true), true),
+          StructField("something", StringType, true),
+          StructField(
+            "struct",
+            StructType(
+              StructType(
+                Seq(
+                  StructField("something", StringType, false),
+                  StructField("mood", ArrayType(StringType, containsNull = false), true),
+                  StructField(
+                    "something3",
+                    StructType(
+                      Seq(
+                        StructField("mood3", ArrayType(StringType, containsNull = false), true)
+                      )
+                    ),
+                    false
+                  )
+                )
+              )
+            ),
+            true
+          )
+        )
+      )
+
+      val e = intercept[DatasetSchemaMismatch] {
+        SchemaComparer.assertSchemaEqual(s1, s2, ignoreColumnOrder = false, outputFormat = SchemaDiffOutputFormat.Tree)
+      }
+
+      val expectedMessage = """Diffs
+          |
+          |Actual Schema                                                      Expected Schema
+          |\u001b[90m|--\u001b[39m \u001b[90marray\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                                 \u001b[90m|--\u001b[39m \u001b[90marray\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|--\u001b[39m \u001b[31mmap\u001b[39m : \u001b[31mmap\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                                     \u001b[90m|--\u001b[39m \u001b[32msomething\u001b[39m : \u001b[32mstring\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|--\u001b[39m \u001b[31msomething\u001b[39m : \u001b[31mstring\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                            \u001b[90m|--\u001b[39m \u001b[32mstruct\u001b[39m : \u001b[32mstruct\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[31m|--\u001b[39m \u001b[31mstruct\u001b[39m : \u001b[31mstruct\u001b[39m (nullable = \u001b[31mtrue\u001b[39m)                               \u001b[32m|    |--\u001b[39m \u001b[32msomething\u001b[39m : \u001b[32mstring\u001b[39m (nullable = \u001b[32mfalse\u001b[39m)
+          |\u001b[90m|    |--\u001b[39m \u001b[90mmood\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                             \u001b[90m|    |--\u001b[39m \u001b[90mmood\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|    |--\u001b[39m \u001b[31msomething\u001b[39m : \u001b[31mstring\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)                      \u001b[90m|    |--\u001b[39m \u001b[32msomething3\u001b[39m : \u001b[32mstruct\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)
+          |\u001b[31m|    |--\u001b[39m \u001b[31msomething2\u001b[39m : \u001b[31mstruct\u001b[39m (nullable = \u001b[31mfalse\u001b[39m)                     \u001b[32m|    |    |--\u001b[39m \u001b[32mmood3\u001b[39m : \u001b[32marray\u001b[39m (nullable = \u001b[32mtrue\u001b[39m)
+          |\u001b[31m|    |    |--\u001b[39m \u001b[31mmood2\u001b[39m : \u001b[31marray\u001b[39m (nullable = \u001b[31mtrue\u001b[39m)
+          |\u001b[31m|    |    |--\u001b[39m \u001b[31msomething2\u001b[39m : \u001b[31mstruct\u001b[39m (nullable = \u001b[31mfalse\u001b[39m)
+          |\u001b[31m|    |    |    |--\u001b[39m \u001b[31mmood2\u001b[39m : \u001b[31marray\u001b[39m (nullable = \u001b[31mtrue\u001b[39m)
+          |\u001b[31m|    |    |    |--\u001b[39m \u001b[31msomething2\u001b[39m : \u001b[31mstruct\u001b[39m (nullable = \u001b[31mfalse\u001b[39m)
+          |\u001b[31m|    |    |    |    |--\u001b[39m \u001b[31mmood2\u001b[39m : \u001b[31marray\u001b[39m (nullable = \u001b[31mtrue\u001b[39m)
+          |\u001b[31m|    |    |    |    |--\u001b[39m \u001b[31msomething2\u001b[39m : \u001b[31mstring\u001b[39m (nullable = \u001b[31mfalse\u001b[39m)
+          |""".stripMargin
+      val actual = e.getMessage
+      println(actual)
+      println(expectedMessage)
       assert(e.getMessage == expectedMessage)
     }
   }

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/SchemaComparerTest.scala
@@ -275,8 +275,8 @@ class SchemaComparerTest extends AnyFreeSpec {
       )
       val s2 = StructType(
         Seq(
-          StructField("something", StringType, true),
           StructField("array", ArrayType(StringType, containsNull = true), true),
+          StructField("something", StringType, true),
           StructField("map", MapType(StringType, StringType, valueContainsNull = false), true),
           StructField(
             "struct",
@@ -304,10 +304,22 @@ class SchemaComparerTest extends AnyFreeSpec {
       )
 
       val e = intercept[DatasetSchemaMismatch] {
-        SchemaComparer.assertSchemaEqual(s1, s2, ignoreColumnOrder = false)
+        SchemaComparer.assertSchemaEqual(s1, s2, ignoreColumnOrder = false, outputFormat = SchemaDiffOutputFormat.Tree)
       }
-      println(e)
-
+      val expectedMessage = """Diffs
+          |
+          |Actual Schema                                      Expected Schema
+          |\u001b[90m|--\u001b[39m \u001b[90marray\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                       \u001b[90m|--\u001b[39m \u001b[90marray\u001b[39m : \u001b[90marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|--\u001b[39m \u001b[31mmap\u001b[39m : \u001b[31mmap\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                           \u001b[90m|--\u001b[39m \u001b[32msomething\u001b[39m : \u001b[32mstring\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|--\u001b[39m \u001b[31msomething\u001b[39m : \u001b[31mstring\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                  \u001b[90m|--\u001b[39m \u001b[32mmap\u001b[39m : \u001b[32mmap\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|--\u001b[39m \u001b[90mstruct\u001b[39m : \u001b[31mstruct\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)                     \u001b[90m|--\u001b[39m \u001b[90mstruct\u001b[39m : \u001b[32mstruct\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[90m|    |--\u001b[39m \u001b[31mmood\u001b[39m : \u001b[31marray\u001b[39m (nullable = \u001b[31mtrue\u001b[39m)                   \u001b[90m|    |--\u001b[39m \u001b[32msomething\u001b[39m : \u001b[32mstring\u001b[39m (nullable = \u001b[32mfalse\u001b[39m)
+          |\u001b[90m|    |--\u001b[39m \u001b[31msomething\u001b[39m : \u001b[31mstring\u001b[39m (nullable = \u001b[31mfalse\u001b[39m)            \u001b[90m|    |--\u001b[39m \u001b[32mmood\u001b[39m : \u001b[32marray\u001b[39m (nullable = \u001b[32mtrue\u001b[39m)
+          |\u001b[90m|    |--\u001b[39m \u001b[31msomething2\u001b[39m : \u001b[31mstruct\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)           \u001b[90m|    |--\u001b[39m \u001b[32msomething3\u001b[39m : \u001b[32mstruct\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)
+          |\u001b[90m|    |    |--\u001b[39m \u001b[31mmood2\u001b[39m : \u001b[31marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)             \u001b[90m|    |    |--\u001b[39m \u001b[32mmood3\u001b[39m : \u001b[32marray\u001b[39m (nullable = \u001b[90mtrue\u001b[39m)
+          |\u001b[31m|    |    |--\u001b[39m \u001b[31msomething2\u001b[39m : \u001b[90mstring\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)      \u001b[32m|--\u001b[39m \u001b[32mnorma2\u001b[39m : \u001b[90mstring\u001b[39m (nullable = \u001b[90mfalse\u001b[39m)
+          |""".stripMargin
+      assert(e.getMessage == expectedMessage)
     }
   }
 }


### PR DESCRIPTION
Add support for display Tree String color diff for schema:
Currently available with `assertSchemaDiff` with `SchemaDiffOutputFormat.Tree` 
<img width="716" alt="image" src="https://github.com/user-attachments/assets/ab1159c5-0b0f-4d69-b290-db4ef6db4f53">
