### PR TITLE
Fix Sonatype Central Ci release (#20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: coursier/setup-action@v1
         with:
-          jvm: zulu:8
+          jvm: zulu:11
       - name: Setup sbt launcher
         uses: sbt/setup-sbt@v1
         with:


### PR DESCRIPTION
https://github.com/xerial/sbt-sonatype/issues/548

Also looks like sbt-sonatype will no longer support java 8

https://github.com/xerial/sbt-sonatype/issues/530

I managed to publish to [sonatype ](https://central.sonatype.com/) from my fork but it does not allow publish to maven due to my account not owning the namespace