### PR TITLE
Fix showProductDiff fail with NullPointerException when unequal Datas…

### DIFF
--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -19,12 +19,7 @@ object ProductUtil {
     }
   }
 
-  private def rowFieldToString(fieldValue: Any): String = {
-    fieldValue match {
-      case null => "null"
-      case _    => fieldValue.toString
-    }
-  }
+  private def rowFieldToString(fieldValue: Any): String = s"$fieldValue"
 
   private[mrpowers] def showProductDiff[T: ClassTag](
       header: (String, String),

--- a/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
+++ b/core/src/main/scala/com/github/mrpowers/spark/fast/tests/ProductUtil.scala
@@ -18,6 +18,14 @@ object ProductUtil {
       case s              => Seq(s)
     }
   }
+
+  private def rowFieldToString(fieldValue: Any): String = {
+    fieldValue match {
+      case null => "null"
+      case _    => fieldValue.toString
+    }
+  }
+
   private[mrpowers] def showProductDiff[T: ClassTag](
       header: (String, String),
       actual: Seq[T],
@@ -55,13 +63,12 @@ object ProductUtil {
           if (allFieldsAreNotEqual) {
             List(Red(prodToString(actualSeq)), Green(prodToString(expectedSeq)))
           } else {
-            val coloredDiff = withEquals
-              .map {
-                case (actualRowField, expectedRowField, true) =>
-                  (DarkGray(actualRowField.toString), DarkGray(expectedRowField.toString))
-                case (actualRowField, expectedRowField, false) =>
-                  (Red(actualRowField.toString), Green(expectedRowField.toString))
-              }
+            val coloredDiff = withEquals.map {
+              case (actualRowField, expectedRowField, true) =>
+                (DarkGray(rowFieldToString(actualRowField)), DarkGray(rowFieldToString(expectedRowField)))
+              case (actualRowField, expectedRowField, false) =>
+                (Red(rowFieldToString(actualRowField)), Green(rowFieldToString(expectedRowField)))
+            }
             val start = DarkGray(s"$className$lBracket")
             val sep   = DarkGray(",")
             val end   = DarkGray(rBracket)

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DataFrameComparerTest.scala
@@ -75,6 +75,40 @@ class DataFrameComparerTest extends AnyFreeSpec with DataFrameComparer with Spar
     e.assertColorDiff(Seq("france", "[mark,11,usa]"), Seq("uk", "[steve,10,aus]"))
   }
 
+  "Can handle unequal Dataframe containing null" in {
+    val sourceDF = spark.createDF(
+      List(
+        ("bob", 1, "uk"),
+        (null, 5, "peru"),
+        ("steve", 10, "aus")
+      ),
+      List(
+        ("name", StringType, true),
+        ("age", IntegerType, true),
+        ("country", StringType, true)
+      )
+    )
+
+    val expectedDF = spark.createDF(
+      List(
+        ("bob", 1, "uk"),
+        (null, 5, "peru"),
+        (null, 10, "aus")
+      ),
+      List(
+        ("name", StringType, true),
+        ("age", IntegerType, true),
+        ("country", StringType, true)
+      )
+    )
+
+    val e = intercept[DatasetContentMismatch] {
+      assertSmallDataFrameEquality(expectedDF, sourceDF)
+    }
+
+    e.assertColorDiff(Seq("null"), Seq("steve"))
+  }
+
   "works well for wide DataFrames" in {
     val sourceDF = spark.createDF(
       List(

--- a/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
+++ b/core/src/test/scala/com/github/mrpowers/spark/fast/tests/DatasetComparerTest.scala
@@ -41,6 +41,17 @@ class DatasetComparerTest extends AnyFreeSpec with DatasetComparer with SparkSes
       }
     }
 
+    "can compare unequal Dataset containing null in column" in {
+      val sourceDS   = Seq(Person(null, 5), Person(null, 1)).toDS
+      val expectedDS = Seq(Person("juan", 5), Person(null, 1)).toDS
+
+      val e = intercept[DatasetContentMismatch] {
+        assertSmallDatasetEquality(sourceDS, expectedDS, ignoreNullable = true, orderedComparison = false)
+      }
+
+      e.assertColorDiff(Seq("null"), Seq("juan"))
+    }
+
     "Correctly mark unequal elements" in {
       val sourceDS = Seq(
         Person("juan", 5),


### PR DESCRIPTION
Fix `showProductDiff` fail with `NullPointerException` when unequal Dataset containing null

Currently when 2 Dataset containing null are unequal we will get a `NullPointerException` when trying to show the diff.
```
Expected exception com.github.mrpowers.spark.fast.tests.DatasetContentMismatch to be thrown, but java.lang.NullPointerException was thrown
ScalaTestFailureLocation: com.github.mrpowers.spark.fast.tests.DataFrameComparerTest at (DataFrameComparerTest.scala:105)
org.scalatest.exceptions.TestFailedException: Expected exception com.github.mrpowers.spark.fast.tests.DatasetContentMismatch to be thrown, but java.lang.NullPointerException was thrown
	at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
	at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
	at org.scalatest.freespec.AnyFreeSpec.newAssertionFailedException(AnyFreeSpec.scala:1740)
	at org.scalatest.Assertions.intercept(Assertions.scala:756)
	at org.scalatest.Assertions.intercept$(Assertions.scala:746)
	at org.scalatest.freespec.AnyFreeSpec.intercept(AnyFreeSpec.scala:1740)
	at com.github.mrpowers.spark.fast.tests.DataFrameComparerTest.$anonfun$new$5(DataFrameComparerTest.scala:105)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.freespec.AnyFreeSpecLike$$anon$1.apply(AnyFreeSpecLike.scala:437)
	at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
	at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
	at org.scalatest.freespec.AnyFreeSpec.withFixture(AnyFreeSpec.scala:1740)
	at org.scalatest.freespec.AnyFreeSpecLike.invokeWithFixture$1(AnyFreeSpecLike.scala:435)
	at org.scalatest.freespec.AnyFreeSpecLike.$anonfun$runTest$1(AnyFreeSpecLike.scala:447)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
	at org.scalatest.freespec.AnyFreeSpecLike.runTest(AnyFreeSpecLike.scala:447)
	at org.scalatest.freespec.AnyFreeSpecLike.runTest$(AnyFreeSpecLike.scala:429)
	at org.scalatest.freespec.AnyFreeSpec.runTest(AnyFreeSpec.scala:1740)
	at org.scalatest.freespec.AnyFreeSpecLike.$anonfun$runTests$1(AnyFreeSpecLike.scala:506)
	at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
	at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
	at org.scalatest.freespec.AnyFreeSpecLike.runTests(AnyFreeSpecLike.scala:506)
	at org.scalatest.freespec.AnyFreeSpecLike.runTests$(AnyFreeSpecLike.scala:505)
	at org.scalatest.freespec.AnyFreeSpec.runTests(AnyFreeSpec.scala:1740)
	at org.scalatest.Suite.run(Suite.scala:1114)
	at org.scalatest.Suite.run$(Suite.scala:1096)
	at org.scalatest.freespec.AnyFreeSpec.org$scalatest$freespec$AnyFreeSpecLike$$super$run(AnyFreeSpec.scala:1740)
	at org.scalatest.freespec.AnyFreeSpecLike.$anonfun$run$1(AnyFreeSpecLike.scala:550)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
	at org.scalatest.freespec.AnyFreeSpecLike.run(AnyFreeSpecLike.scala:550)
	at org.scalatest.freespec.AnyFreeSpecLike.run$(AnyFreeSpecLike.scala:549)
	at org.scalatest.freespec.AnyFreeSpec.run(AnyFreeSpec.scala:1740)
	at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:47)
	at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1321)
	at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1315)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1315)
	at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:992)
	at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:970)
	at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1481)
	at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:970)
	at org.scalatest.tools.Runner$.run(Runner.scala:798)
	at org.scalatest.tools.Runner.run(Runner.scala)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.runScalaTest2or3(ScalaTestRunner.java:43)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.main(ScalaTestRunner.java:26)

```